### PR TITLE
Created basic dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# Base image
+FROM ubuntu:14.04
+
+# No interaction during install
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Install essentials
+RUN apt-get -qqy update && \
+    apt-get -qqy install \
+    build-essential \
+    libopenmpi-dev \
+    openmpi-bin \
+    libgsl0-dev \
+    git \
+    curl
+
+# Load fastpm into docker
+WORKDIR /fastpm
+COPY . .
+
+# Build fastpm
+RUN cd /fastpm && \
+	echo "CC = mpicc\nOPENMP = -fopenmp\nCPPFLAGS = -DFASTPM_FFT_PRECISION=32\nOPTIMIZE = -O3 -g" > Makefile.local && \
+	make
+
+# Expose an address for jupyter notebooks
+EXPOSE 8888
+
+# Folder which can be used for connecting data directories
+WORKDIR /workspace
+
+ENTRYPOINT ["/bin/bash"]

--- a/README.rst
+++ b/README.rst
@@ -177,6 +177,27 @@ currently the compiler on these Macintosh Personal Computers do not support open
 The compiler is also gives extra warnings, and remove `-Werror` from the Makefile.local
 is recommended.
 
+Docker
+------
+
+There is a basic docker configuration file to set up a container
+for FastPM. 
+
+To build it, run:
+
+.. code::
+
+    docker build -t fastpm .
+
+To start the docker container in interactive mode,
+with port 8888 exposed and with
+``/my/file/directory`` linked, run
+
+.. code::
+
+    docker run -it -v /my/file/directory:/workspace -p 8888:8888 fastpm
+
+
 Examples
 --------
 


### PR DESCRIPTION
- Runs on ubuntu 14.04 docker base image
- Has only the essentials for building fastpm
- Exposes port 8888 for notebooks (though you will have to include or install python, jupyter manually)

To build, `cd` into the fastpm directory, then:
`docker build -t fastpm .`

To run in interactive mode with a port exposed and with a file directory linked:
`docker run -it -v /my/file/directory:/workspace --name fastpm1 -p 8888:8888 fastpm`