### PR TITLE
Fix fnl

### DIFF
--- a/libfastpm/pngaussian.c
+++ b/libfastpm/pngaussian.c
@@ -137,6 +137,7 @@ fastpm_png_transform_potential(PM * pm, FastPMFloat * delta_k, FastPMPNGaussian 
     fastpm_info("Expected_avg_g_squared: %g, when there is no gaussian variance\n", avg_g_squared_exp);
     fastpm_info("avg_g_squared: %g, %g\n", avg_g_squared, avg_g_squared*avg_g_squared);
 
+    /* Use the realization mean because we want the mean of linear field to be exactly zero. */
     for(i = 0; i < pm_allocsize(pm); i ++) {
         g_x[i] = g_x[i] + png->fNL * ( g_x2[i] * g_x2[i] - avg_g_squared );
     }


### PR DESCRIPTION
This fixes the truncation of power spectrum in fNL.

The old treatment truncates the gaussian. It reduces the clustering on small scale so much such that the simulation is lacking halos in the low mass end, severely -- found by @ecastorina

This PR truncates only the non-gaussian part. Hopefully it doesn't cause more missing troubles. 
