### PR TITLE
Allow input linear power spectrum at any redshift.

### DIFF
--- a/src/lua-runtime-fastpm.lua
+++ b/src/lua-runtime-fastpm.lua
@@ -79,8 +79,9 @@ schema.declare{name='read_lineark',        type='string'}
 schema.declare{name='read_runpbic',       type='string'}
 schema.declare{name='read_whitenoisek',         type='string'}
 
-schema.declare{name='read_powerspectrum', type='file'}
-schema.declare{name='sigma8',             type='number', default=0}
+schema.declare{name='read_powerspectrum', type='file', help='file to read the linear power spectrum.'}
+schema.declare{name='linear_density_redshift', type='number', default=0, help='redshift of the input linear density field. '}
+schema.declare{name='sigma8',             type='number', default=0, help='normalize linear power spectrumt to sigma8(z); this shall be sigma8 at linear_density_redshift, not z=0.'}
 schema.declare{name='random_seed',         type='int'}
 schema.declare{name='shift',             type='boolean', default=false}
 schema.declare{name='inverted_ic',             type='boolean', default=false}

--- a/tests/nbodykit.lua
+++ b/tests/nbodykit.lua
@@ -18,14 +18,15 @@ output_redshifts= {0.0}  -- redshifts of output
 omega_m = 0.307494
 h       = 0.6774
 
--- Start with a power spectrum file
--- Initial power spectrum: k P(k) in Mpc/h units
+-- Start with a linear density field
+-- Power spectrum of the linear density field: k P(k) in Mpc/h units
 -- Must be compatible with the Cosmology parameter
 read_powerspectrum= "powerspec.txt"
+linear_density_redshift = 0.0 -- the redshift of the linear density field.
 random_seed= 100
 
 -------- Approximation Method ---------------
-force_mode = "pm"
+force_mode = "fastpm"
 
 pm_nc_factor = 2
 


### PR DESCRIPTION
As an example,
consider two models:
- linear theory, cosmology 1
- FastPM cosmology 2
Using linear theory at z=0.2 as an input to FastPM, and setting linear_density_redshift =0.2,
The nonlinear density field at z=0.2 will match linear density at linear scales.
But no other redshifts shall match.