### PR TITLE
Fix: Crashes when procmesh does not divide Nc

### DIFF
--- a/libfastpm/solver.c
+++ b/libfastpm/solver.c
@@ -72,9 +72,9 @@ void fastpm_solver_init(FastPMSolver * fastpm,
     PMInit basepminit = {
             .Nmesh = config->nc,
             .BoxSize = config->boxsize,
-            .NprocY = 0, /* 0 for auto, 1 for slabs */
+            .NprocY = config->NprocY, /* 0 for auto, 1 for slabs */
             .transposed = 1,
-            .use_fftw = 0,
+            .use_fftw = config->UseFFTW,
         };
 
     fastpm->basepm = malloc(sizeof(PM));

--- a/src/fastpm-lua.c
+++ b/src/fastpm-lua.c
@@ -65,6 +65,7 @@ int main(int argc, char * argv[]) {
         if(confstr == NULL) {
             fastpm_raise(-1, "%s\n", error);
         }
+        fastpm_info("Compiled parameters are: \n%s\n", confstr);
         LuaConfig * config;
         config = lua_config_new(confstr);
         lua_config_free(config);


### PR DESCRIPTION
When some of the ranks are left idling by pfft, the edge were not properly calculated --
set to zero instead of keeping the previous edge. This is a known issue in PFFT:
https://github.com/mpip/pfft/issues/22

We work around it here by summing up the sizes.