### PR TITLE
Change the decomposition of the fof halo finder.

### DIFF
--- a/api/fastpm/fof.h
+++ b/api/fastpm/fof.h
@@ -15,7 +15,6 @@ typedef struct {
     int nmin;
     double linkinglength; /* absolute */
     int periodic;
-    FastPMStore halos[1];
     int kdtree_thresh;
 
     FastPMStore * p;

--- a/api/fastpm/store.h
+++ b/api/fastpm/store.h
@@ -158,6 +158,9 @@ void
 fastpm_store_copy(FastPMStore * in, FastPMStore * out);
 
 void
+fastpm_store_take(FastPMStore * in, ptrdiff_t i, FastPMStore * out, ptrdiff_t j);
+
+void
 fastpm_store_append(FastPMStore * in, FastPMStore * out);
 
 void fastpm_store_get_position(FastPMStore * p, ptrdiff_t index, double pos[3]);

--- a/api/fastpm/store.h
+++ b/api/fastpm/store.h
@@ -22,6 +22,7 @@ enum FastPMPackFields {
     PACK_MASK    =  1L << 13,
     PACK_RDISP =  1L << 14,
     PACK_VDISP =  1L << 15,
+    PACK_RVDISP =  1L << 16,
 
 
     PACK_ACC_X =  1L << 20,
@@ -78,8 +79,9 @@ struct FastPMStore {
         int64_t task; /* to fill up the 8 bytes alignment */
      } * fof;
     int32_t * length;
-    float (* rdisp)[6];
+    float (* rdisp)[6]; /* zero lag, first lag, second lag */
     float (* vdisp)[6];
+    float (* rvdisp)[9];
 
     size_t np;
     size_t np_upper;

--- a/api/fastpm/store.h
+++ b/api/fastpm/store.h
@@ -20,6 +20,8 @@ enum FastPMPackFields {
     PACK_FOF =  1L << 11,
     PACK_LENGTH =  1L << 12,
     PACK_MASK    =  1L << 13,
+    PACK_RDISP =  1L << 14,
+    PACK_VDISP =  1L << 15,
 
 
     PACK_ACC_X =  1L << 20,
@@ -76,6 +78,8 @@ struct FastPMStore {
         int64_t task; /* to fill up the 8 bytes alignment */
      } * fof;
     int32_t * length;
+    float (* rdisp)[6];
+    float (* vdisp)[6];
 
     size_t np;
     size_t np_upper;

--- a/api/fastpm/store.h
+++ b/api/fastpm/store.h
@@ -116,7 +116,16 @@ typedef int (*fastpm_store_target_func)(void * pdata, ptrdiff_t index, void * da
 int
 fastpm_store_decompose(FastPMStore * p, fastpm_store_target_func target_func, void * data, MPI_Comm comm);
 
-void fastpm_store_sort_by_id(FastPMStore * p);
+void
+fastpm_store_permute(FastPMStore * p, int * ind);
+
+int
+FastPMLocalSortByID(const int i1,
+                    const int i2,
+                    FastPMStore * p);
+
+void
+fastpm_store_sort(FastPMStore * p, int (*cmpfunc)(const int i1, const int i2, FastPMStore * p));
 
 size_t
 fastpm_store_get_np_total(FastPMStore * p, MPI_Comm comm);

--- a/libfastpm/fof.c
+++ b/libfastpm/fof.c
@@ -41,7 +41,19 @@ struct KDTreeNodeBuffer {
 };
 
 static void
-fastpm_fof_compute_halo_attrs (FastPMFOFFinder * finder, FastPMStore * halos, ptrdiff_t * head);
+fastpm_fof_compute_local_halo_attrs (FastPMFOFFinder * finder, FastPMStore * halos, struct FastPMFOFData * fofsave, ptrdiff_t * head, size_t np_and_ghosts);
+
+static void
+fastpm_fof_reduce_sorted_local_halo_attrs(FastPMFOFFinder * finder, FastPMStore * halos);
+
+static void
+fastpm_fof_add_halo_attrs(FastPMFOFFinder * finder, FastPMStore * halos, int hid, FastPMStore * h1, int i);
+
+static void
+fastpm_fof_create_local_halos(FastPMFOFFinder * finder, FastPMStore * halos, size_t nhalos);
+
+static void
+fastpm_fof_convert_particle_to_halo(FastPMStore * p, ptrdiff_t i, FastPMStore * halos);
 
 static void *
 _kdtree_buffered_malloc(void * userdata, size_t size)
@@ -223,10 +235,27 @@ _merge(struct FastPMFOFData * remote, struct FastPMFOFData * fofhead)
 }
 
 static int
-FastPMTargetFOF(FastPMStore * store, ptrdiff_t i, void ** userdata)
+_merge2(struct FastPMFOFData * remote, struct FastPMFOFData * fofhead)
 {
-    struct FastPMFOFData * fof = userdata[0];
-    return fof[i].task;
+    int merge = 0;
+    if(remote->minid < fofhead->minid) {
+        merge = 1;
+    }
+    if(remote->minid == fofhead->minid &&
+       remote->task != fofhead->task &&
+       remote->task >= 0) {
+        merge = 1;
+    }
+
+    if(merge) {
+/*
+        if(fofhead->minid != remote->minid)
+            printf("merging minid %ld setting to %ld\n", fofhead->minid, remote->minid);
+*/
+        fofhead->minid = remote->minid;
+        fofhead->task = remote->task;
+    }
+    return merge;
 }
 
 static void
@@ -290,7 +319,8 @@ _fof_global_merge(
         }
         size_t nmerged = 0;
         for(i = p->np; i < p->np + pgd->p->np; i ++) {
-            nmerged += _merge(&fofcomm[i], &fofsave[head[i]]);
+            int m = _merge2(&fofcomm[i], &fofsave[head[i]]);
+            nmerged += m;
         }
 
         /* at this point all items on fofsave with head[i] = i have present minid and task */
@@ -318,17 +348,116 @@ _fof_global_merge(
                 finder->priv->ThisTask, p->id[i], p->id[head[i]], i, p->np, fofcomm[i].minid, fofcomm[i].task);
         }
         fofsave[i].minid = fofcomm[i].minid;
-        fofsave[i].minid = fofcomm[i].minid;
+        fofsave[i].task = fofcomm[i].task;
+    }
+    for(i = p->np; i < p->np + pgd->p->np; i ++) {
+        fofsave[i].task = -1;
     }
 
     fastpm_memory_free(p->mem, fofcomm);
 }
 
-static void
-fastpm_fof_find_halos(FastPMFOFFinder * finder, FastPMStore * p, PM * pm, struct FastPMFOFData ** labels)
+static size_t
+_assign_halo_attr(ptrdiff_t * head, ptrdiff_t * offset, size_t np, int nmin)
 {
+    ptrdiff_t i;
+    for(i = 0; i < np; i ++) {
+        offset[i] = 0;
+    }
 
+    /* set offset to number of particles in the halo */
+    for(i = 0; i < np; i ++) {
+        offset[head[i]] ++;
+    }
+
+    size_t it = 0;
+    
+    ptrdiff_t max = 0;
+    /* assign attr index */
+    for(i = 0; i < np; i ++) {
+        if(offset[i] > max) {
+            max = offset[i];
+        }
+        if(offset[i] >= nmin) {
+            offset[i] = it;
+            it ++;
+        } else {
+            offset[i] = -1;
+        }
+    }
+
+    size_t nhalos = it;
+
+    /* update head [i] to offset[head[i]], which stores the index in the halo store for this particle. */
+    for(i = 0; i < np; i ++) {
+        head[i] = offset[head[i]];
+        if(head[i] != -1 && head[i] > nhalos) {
+            fastpm_raise(-1, "head[i] (%td) > nhalos (%td) This shall not happend\n", head[i], nhalos);
+        }
+    }
+
+    return it;
+}
+static double
+periodic_add(double x, double wx, double y, double wy, double L)
+{
+    if(wx > 0) {
+        while(y - x > L / 2) y -= L;
+        while(y - x < -L / 2) y += L;
+
+        return wx * x + wy * y;
+    } else {
+        return wy * y;
+    }
+}
+
+/* first every undecided halo; then the real halo with particles */
+static int
+FastPMLocalSortByMinID(const int i1,
+                    const int i2,
+                    FastPMStore * p)
+{
+    int d1 = (p->fof[i1].task == -1);
+    int d2 = (p->fof[i2].task == -1);
+
+    if(d1 != d2) return d2 - d1;
+
+    int v1 = (p->fof[i1].minid < p->fof[i2].minid);
+    int v2 = (p->fof[i1].minid > p->fof[i2].minid);
+
+    return v2 - v1;
+}
+
+static int
+FastPMTargetMinID(FastPMStore * store, ptrdiff_t i, void * userdata)
+{
+    FastPMFOFFinder * finder = userdata;
+
+    if(store->fof[i].task != -1) {
+        return store->fof[i].minid % finder->priv->NTask;
+    } else {
+        return finder->priv->ThisTask;
+    }
+}
+
+static int
+FastPMTargetTask(FastPMStore * store, ptrdiff_t i, void * userdata)
+{
+    FastPMFOFFinder * finder = userdata;
+
+    if(store->fof[i].task != -1)
+        return store->fof[i].task;
+    else
+        return finder->priv->ThisTask;
+}
+
+
+void
+fastpm_fof_execute(FastPMFOFFinder * finder, FastPMStore * halos)
+{
     /* initial decompose -- reduce number of ghosts */
+    FastPMStore * p = finder->p;
+    PM * pm = finder->pm;
 
     /* only do wrapping for periodic data */
     if(finder->priv->boxsize)
@@ -372,137 +501,82 @@ fastpm_fof_find_halos(FastPMFOFFinder * finder, FastPMStore * p, PM * pm, struct
 
     pm_ghosts_send(pgd, PACK_POS | PACK_ID);
 
-    struct FastPMFOFData * fofsave = fastpm_memory_alloc(p->mem, "FOFSave",
-                    sizeof(fofsave[0]) * (p->np + pgd->p->np), FASTPM_MEMORY_STACK);
+    size_t np_and_ghosts = p->np + pgd->p->np;
 
     ptrdiff_t * head = fastpm_memory_alloc(p->mem, "FOFHead",
-                    sizeof(head[0]) * (p->np + pgd->p->np), FASTPM_MEMORY_STACK);
+                    sizeof(head[0]) * np_and_ghosts, FASTPM_MEMORY_STACK);
+
+    struct FastPMFOFData * fofsave = fastpm_memory_alloc(p->mem, "FOFSave",
+                    sizeof(fofsave[0]) * np_and_ghosts, FASTPM_MEMORY_STACK);
 
     _fof_local_find(finder, p, pgd, head, finder->linkinglength);
 
     _fof_global_merge (finder, pgd, fofsave, head);
 
-    fastpm_memory_free(p->mem, head);
+    ptrdiff_t * offset = fastpm_memory_alloc(finder->p->mem, "FOFOffset", sizeof(offset[0]) * np_and_ghosts, FASTPM_MEMORY_STACK);
+
+    size_t nhalos = _assign_halo_attr(head, offset, np_and_ghosts, 1);
+
+    fastpm_info("Found %td halos segments >= %d particles\n", nhalos, 1);
+
+    fastpm_memory_free(finder->p->mem, offset);
 
     pm_ghosts_free(pgd);
 
-    *labels = fofsave;
+    /* create local halos and modify head to index the local halos */
+    fastpm_fof_create_local_halos(finder, halos, nhalos);
 
-#if 0
-    BigFile bf = {0};
-    big_file_mpi_create(&bf, fastpm_strdup_printf("dump-fof-%d", pm->NTask), pm_comm(pm));
-    write_snapshot_data(p, 1, 1, FastPMSnapshotSortByID, 0, &bf, "1", pm_comm(pm));
-    big_file_mpi_close(&bf, pm_comm(pm));
-#endif
+    /* now halos[head[i]] is the halo attribute of particle i. */
 
-}
-
-static void
-fastpm_fof_decompose(FastPMFOFFinder * finder, FastPMStore * p, PM * pm, struct FastPMFOFData * fofsave)
-{
-/* real decompose, move particles of the same halo to the same rank */
-#if 0
-    /* for the assertion below only. need fofcomm to be as long as np_upper. */
-    p->fof = fofcomm;
-    p->attributes |= PACK_FOF;
-
-#endif
-    void * userdata[1] = {fofsave};
-
-    if(0 != fastpm_store_decompose(p,
-                (fastpm_store_target_func) FastPMTargetFOF,
-                userdata, pm_comm(pm))) {
-        fastpm_raise(-1, "out of storage space decomposing for FOF\n");
-    }
-#if 0
-    ptrdiff_t i;
-    for(i = 0; i < p->np; i ++) {
-        if(p->fof[i].task != finder->priv->ThisTask) abort();
-    }
-
-    p->attributes &= ~PACK_FOF;
-    p->fof = NULL;
-#endif
-
-    double npmax, npmin, npstd, npmean;
-
-    MPIU_stats(pm_comm(pm), p->np, "<->s", &npmin, &npmean, &npmax, &npstd);
-
-    fastpm_info("load balance after second decompose : min = %g max = %g mean = %g std = %g\n",
-        npmin, npmax, npmean, npstd
-        );
-}
-
-static size_t
-_assign_halo_attr(ptrdiff_t * head, ptrdiff_t * offset, size_t np, int nmin)
-{
-    ptrdiff_t i;
-    for(i = 0; i < np; i ++) {
-        offset[i] = 0;
-    }
-
-    /* set offset to number of particles in the halo */
-    for(i = 0; i < np; i ++) {
-        offset[head[i]] ++;
-    }
-
-    size_t it = 0;
-    
-    ptrdiff_t max = 0;
-    /* assign attr index */
-    for(i = 0; i < np; i ++) {
-        if(offset[i] > max) {
-            max = offset[i];
-        }
-        if(offset[i] >= nmin) {
-            offset[i] = it;
-            it ++;
-        } else {
-            offset[i] = -1;
-        }
-    }
-    return it;
-}
-static double
-periodic_add(double x, double wx, double y, double wy, double L)
-{
-    if(wx > 0) {
-        while(y - x > L / 2) y -= L;
-        while(y - x < -L / 2) y += L;
-
-        return wx * x + wy * y;
-    } else {
-        return wy * y;
-    }
-}
-
-void
-fastpm_fof_execute(FastPMFOFFinder * finder, FastPMStore * halos)
-{
-
-    struct FastPMFOFData * fofsave = NULL;
-
-    fastpm_fof_find_halos(finder, finder->p, finder->pm, &fofsave);
-
-    fastpm_fof_decompose(finder, finder->p, finder->pm, fofsave);
+    /* now add the local attributes */
+    fastpm_fof_compute_local_halo_attrs(finder, halos, fofsave, head, np_and_ghosts);
 
     fastpm_memory_free(finder->p->mem, fofsave);
 
-    KDTree tree;
+    /* decompose halos by minid (gather) */
+    if(0 != fastpm_store_decompose(halos,
+            (fastpm_store_target_func) FastPMTargetMinID, finder, pm_comm(pm))) {
 
-    ptrdiff_t * head = fastpm_memory_alloc(finder->p->mem, "FOFHead", sizeof(head[0]) * finder->p->np, FASTPM_MEMORY_STACK);
+        fastpm_raise(-1, "out of space for halos decomposition.\n");
+    }
 
-    /* redo fof on the new decomposition -- no halo cross two ranks */
-    KDNode * root = _create_kdtree(&tree, finder->kdtree_thresh, &(finder->p), 1, finder->priv->boxsize);
+    /* now head[i] is no longer the halo attribute of particle i. */
 
-    kd_fof(root, finder->linkinglength, head);
+    /* local sort by minid */
+    fastpm_store_sort(halos, FastPMLocalSortByMinID);
 
-    _free_kdtree(&tree, root);
+    /* reduce and update properties */
+    /* set halos->mask. */
+    fastpm_fof_reduce_sorted_local_halo_attrs(finder, halos);
 
-    /* now do the attributes */
+#if 0
+    if (finder->priv->ThisTask == 0)
+    {
+        FILE * fp;
+        fp = fopen("dumpfof.data", "w");
+        fwrite(halos->fof, halos->np, sizeof(halos->fof[0]), fp);
+        fclose(fp);
+        fp = fopen("dumpfof.mask", "w");
+        fwrite(halos->mask, halos->np, sizeof(halos->mask[0]), fp);
+        fclose(fp);
+    }
+#endif
 
-    fastpm_fof_compute_halo_attrs(finder, halos, head);
+    /* decompose halos by task (return) */
+    if (0 != fastpm_store_decompose(halos,
+            (fastpm_store_target_func) FastPMTargetTask, finder, pm_comm(pm))) {
+        fastpm_raise(-1, "out of space for halos decomposition.\n");
+    }
 
+    /* local sort by id (restore the order) */
+    fastpm_store_sort(halos, FastPMLocalSortByID);
+
+    /* now head[i] is again the halo attribute of particle i. */
+
+    /* the event is called with full halos, only those where mask==1 are primary
+     * the others are ghosts with the correct properties but shall not show up in the
+     * catalog.
+     * */
     FastPMHaloEvent event[1];
     event->halos = halos;
     event->p = finder->p;
@@ -517,55 +591,55 @@ fastpm_fof_execute(FastPMFOFFinder * finder, FastPMStore * halos)
 }
 
 static void
-fastpm_fof_compute_halo_attrs (FastPMFOFFinder * finder, FastPMStore * halos, ptrdiff_t * head)
+fastpm_fof_create_local_halos(FastPMFOFFinder * finder, FastPMStore * halos, size_t nhalos)
 {
-    ptrdiff_t * offset = fastpm_memory_alloc(finder->p->mem, "FOFOffset", sizeof(offset[0]) * finder->p->np, FASTPM_MEMORY_STACK);
 
-    /* */
-    {
-        size_t nhalos = _assign_halo_attr(head, offset, finder->p->np, finder->nmin);
+    enum FastPMPackFields attributes = finder->p->attributes;
+    attributes |= PACK_LENGTH | PACK_FOF;
+    attributes &= ~PACK_ACC;
+    attributes &= ~PACK_POTENTIAL;
+    attributes &= ~PACK_DENSITY;
+    attributes &= ~PACK_TIDAL;
 
-
-        enum FastPMPackFields attributes = finder->p->attributes;
-        attributes |= PACK_LENGTH | PACK_FOF;
-        attributes &= ~PACK_ACC;
-        attributes &= ~PACK_POTENTIAL;
-        attributes &= ~PACK_DENSITY;
-        attributes &= ~PACK_TIDAL;
-
-        /* store initial position only for periodic case. non-periodic suggests light cone and
-         * we cannot infer q from ID sensibly. (crashes there) */
-        if(finder->priv->boxsize) {
-            attributes |= PACK_Q;
-        } else {
-            attributes &= ~PACK_Q;
-        }
-
-        double avg_halos;
-        /* + 1 to ensure avg_halos > 0 */
-        MPIU_stats(pm_comm(finder->pm), nhalos + 1, "-", &avg_halos);
-
-        /* give it enough space for rebalancing. */
-        fastpm_store_init(halos, nhalos < 2 * avg_halos?2 * avg_halos:nhalos,
-                attributes,
-                FASTPM_MEMORY_HEAP);
-
-        halos->np = nhalos;
-        halos->a_x = finder->p->a_x;
-        halos->a_v = finder->p->a_v;
-
-        MPI_Allreduce(MPI_IN_PLACE, &nhalos, 1, MPI_LONG, MPI_SUM, pm_comm(finder->pm));
-
-        fastpm_info("Found %td halos >= %d particles\n", nhalos, finder->nmin);
+    /* store initial position only for periodic case. non-periodic suggests light cone and
+     * we cannot infer q from ID sensibly. (crashes there) */
+    if(finder->priv->boxsize) {
+        attributes |= PACK_Q;
+    } else {
+        attributes &= ~PACK_Q;
     }
 
+    double avg_halos;
+    /* + 1 to ensure avg_halos > 0 */
+    MPIU_stats(pm_comm(finder->pm), nhalos + 1, "-", &avg_halos);
+
+    /* give it enough space for rebalancing. */
+    fastpm_store_init(halos, nhalos < 2 * avg_halos?2 * avg_halos:nhalos,
+            attributes,
+            FASTPM_MEMORY_HEAP);
+
+    halos->np = nhalos;
+    halos->a_x = finder->p->a_x;
+    halos->a_v = finder->p->a_v;
+
+    MPI_Allreduce(MPI_IN_PLACE, &nhalos, 1, MPI_LONG, MPI_SUM, pm_comm(finder->pm));
+}
+
+/* head is the hid of each particle; fofsave has the minid of each particle (unique label of each halo) */
+static void
+fastpm_fof_compute_local_halo_attrs (FastPMFOFFinder * finder, FastPMStore * halos, struct FastPMFOFData * fofsave, ptrdiff_t * head, size_t np_and_ghosts)
+{
+    FastPMStore h1[1];
+    fastpm_store_init(h1, 1, halos->attributes, FASTPM_MEMORY_HEAP);
+
+    /* */
     ptrdiff_t i;
     for(i = 0; i < halos->np; i++) {
         int d;
         halos->length[i] = 0;
+        halos->id[i] = i;
 
-        if(halos->mask)
-            halos->mask[i] = 1; /* select the halos for output. */
+        halos->mask[i] = 0; /* unselect the halos ; will turn this only if any particle is used */
 
         if(halos->aemit)
             halos->aemit[i] = 0;
@@ -582,65 +656,189 @@ fastpm_fof_compute_halo_attrs (FastPMFOFFinder * finder, FastPMStore * halos, pt
             if(halos->q)
                 halos->q[i][d] = 0;
         }
-        halos->fof[i].minid = (uint64_t) -1;
-        halos->fof[i].task = finder->priv->ThisTask;
+
+        /* if minid is not set, this halo has no particle on this rank, and can be removed. */
+        halos->fof[i].task = -1;
     }
 
-    double * boxsize = finder->priv->boxsize;
+    /* set minid and task of the halo; all of the halo particles of the same minid needs to be reduced */
+    for(i = 0; i < finder->p->np; i++) {
+        /* set the minid of the halo; need to take care of the ghosts too.
+         * even though we do not add them to the attributes */
+        ptrdiff_t hid = head[i];
+        if(halos->mask[hid] == 0) {
+            /* halo will be reduced by minid */
+            halos->fof[hid].minid = fofsave[i].minid;
+            /* halo will be returned to this task */
+            halos->fof[hid].task = finder->priv->ThisTask;
+            halos->mask[hid] = 1;
+        } else {
+            if(halos->fof[hid].minid != fofsave[i].minid) {
+                abort();
+            }
+        }
+    }
 
     for(i = 0; i < finder->p->np; i++) {
-        ptrdiff_t hid = offset[head[i]];
+        ptrdiff_t hid = head[i];
         if(hid < 0) continue;
 
+        if(halos->fof[hid].minid != fofsave[i].minid) {
+            fastpm_raise(-1, "minid of halo disagrees with the particle. This shall not happend\n");
+        }
+
         if(hid >= halos->np) {
-            abort();
+            fastpm_raise(-1, "halo of a particle out of bounds (%td > %td)\n", hid, halos->np);
         }
 
-        if(halos->aemit)
-            halos->aemit[hid] += finder->p->aemit[i];
+        fastpm_fof_convert_particle_to_halo(finder->p, i, h1);
 
-        if(halos->fof[hid].minid > finder->p->id[i]) {
-            halos->fof[hid].minid = finder->p->id[i];
-        }
-
-        int d;
-
-        for(d = 0; d < 3; d++) {
-            if(halos->v)
-                halos->v[hid][d] += finder->p->v[i][d];
-            if(halos->dx1)
-                halos->dx1[hid][d] += finder->p->dx1[i][d];
-            if(halos->dx2)
-                halos->dx2[hid][d] += finder->p->dx2[i][d];
-        }
-        if(halos->x) {
-            for(d = 0; d < 3; d++) {
-                if(boxsize) {
-                    halos->x[hid][d] = periodic_add(
-                        halos->x[hid][d] / halos->length[hid], halos->length[hid],
-                        finder->p->x[i][d], 1, boxsize[d]);
-                } else {
-                    halos->x[hid][d] += finder->p->x[i][d];
-                }
-            }
-        }
-
-        if(halos->q) {
-            double q[3];
-            fastpm_store_get_q_from_id(finder->p, finder->p->id[i], q);
-            for(d = 0; d < 3; d ++) {
-                if (boxsize) {
-                    halos->q[hid][d] = periodic_add(
-                        halos->q[hid][d] / halos->length[hid], halos->length[hid],
-                        q[d], 1, boxsize[d]);
-                } else {
-                    halos->q[hid][d] += q[d];
-                }
-            }
-        }
-        /* do this after the loop because x depends on the old length. */
-        halos->length[hid] += 1;
+        fastpm_fof_add_halo_attrs(finder, halos, hid, h1, 0);
     }
+
+    fastpm_store_destroy(h1);
+}
+
+static void
+fastpm_fof_add_halo_attrs(FastPMFOFFinder * finder, FastPMStore * halos, int hid, FastPMStore * h1, int i)
+{
+    double * boxsize = finder->priv->boxsize;
+
+    if(halos->aemit)
+        halos->aemit[hid] += h1->aemit[i];
+
+    int d;
+
+    for(d = 0; d < 3; d++) {
+        if(halos->v)
+            halos->v[hid][d] += h1->v[i][d];
+        if(halos->dx1)
+            halos->dx1[hid][d] += h1->dx1[i][d];
+        if(halos->dx2)
+            halos->dx2[hid][d] += h1->dx2[i][d];
+    }
+
+    if(halos->x) {
+        for(d = 0; d < 3; d++) {
+            if(boxsize) {
+                halos->x[hid][d] = periodic_add(
+                    halos->x[hid][d] / halos->length[hid], halos->length[hid],
+                    h1->x[i][d] / h1->length[i], h1->length[i], boxsize[d]);
+            } else {
+                halos->x[hid][d] += h1->x[i][d];
+            }
+        }
+    }
+
+    if(halos->q) {
+        for(d = 0; d < 3; d ++) {
+            if (boxsize) {
+                halos->q[hid][d] = periodic_add(
+                    halos->q[hid][d] / halos->length[hid], halos->length[hid],
+                    h1->q[i][d] / h1->length[i], h1->length[i], boxsize[d]);
+            } else {
+                halos->q[hid][d] += h1->q[i][d];
+            }
+        }
+    }
+    /* do this after the loop because x depends on the old length. */
+    halos->length[hid] += h1->length[i];
+}
+
+/* convert a particle to the first halo in the halo store */
+static void
+fastpm_fof_convert_particle_to_halo(FastPMStore * p, ptrdiff_t i, FastPMStore * halos)
+{
+    int hid = 0;
+
+    int d;
+
+    double q[3];
+
+    if(halos->q)
+        fastpm_store_get_q_from_id(p, p->id[i], q);
+
+    halos->length[hid] = 1;
+
+    for(d = 0; d < 3; d++) {
+        if(halos->x)
+            halos->x[hid][d] = p->x[i][d];
+        if(halos->v)
+            halos->v[hid][d] += p->v[i][d];
+        if(halos->dx1)
+            halos->dx1[hid][d] += p->dx1[i][d];
+        if(halos->dx2)
+            halos->dx2[hid][d] += p->dx2[i][d];
+        if(halos->q) {
+            halos->q[hid][d] = q[d];
+        }
+    }
+
+    if(halos->aemit)
+        halos->aemit[hid] = p->aemit[i];
+}
+
+static void
+fastpm_fof_reduce_sorted_local_halo_attrs(FastPMFOFFinder * finder, FastPMStore * halos)
+{
+
+    ptrdiff_t i;
+
+    ptrdiff_t first = -1;
+    uint64_t lastminid = 0;
+    int * ind = fastpm_memory_alloc(finder->p->mem, "HaloPermutation", sizeof(ind[0]) * halos->np, FASTPM_MEMORY_STACK);
+
+    i = 0;
+    while(i < halos->np) {
+        if(halos->fof[i].task != -1) break;
+        ind[i] = i;
+        i++;
+    }
+    for(; i < halos->np + 1; i++) {
+        /* we use i == halos->np to terminate the last segment */
+        if(first == -1 || i == halos->np || lastminid != halos->fof[i].minid) {
+            if (first >= 0) {
+                /* a segment ended */
+                ptrdiff_t j;
+                for(j = first; j < i; j ++) {
+                    ind[j] = first;
+                }
+            }
+            if (i < halos->np) {
+                /* a segment started */
+                halos->mask[i] = 1;
+                lastminid = halos->fof[i].minid;
+            }
+            /* starting a segment of the same halos */
+            first = i;
+        } else {
+            /* inside segment, simply add the ith halo to the first of the segment */
+            halos->mask[i] = 0;
+            fastpm_fof_add_halo_attrs(finder, halos, first, halos, i);
+        }
+    }
+
+    void * fofdata = halos->fof;
+    void * id = halos->id;
+    void * mask = halos->mask;
+
+    /* use permute to replicate the first halo attr to the rest:
+     *
+     * we do not want to replicate
+     * - fof, as fof.task is the original mpi rank of the halo
+     * - id, as it is the original location of the halo on the original mpi rank. 
+     * - mask, whether it is primary or not
+     *   */
+
+    halos->fof = NULL;
+    halos->id = NULL;
+    halos->mask = NULL;
+
+    fastpm_store_permute(halos, ind);
+
+    halos->fof = fofdata;
+    halos->id = id;
+    halos->mask = mask;
 
     for(i = 0; i < halos->np; i++) {
         int d;
@@ -661,17 +859,13 @@ fastpm_fof_compute_halo_attrs (FastPMFOFFinder * finder, FastPMStore * halos, pt
         if(halos->aemit)
             halos->aemit[i] /= n;
 
-        if(halos->id)
-            halos->id[i] = halos->fof[i].minid;
+        /* remove halos that are shorter than nmin */
+        if(halos->mask[i] && halos->length[i] < finder->nmin) {
+            halos->mask[i] = 0;
+        }
     }
 
-    /* update head to hid, for the event. */
-    for(i = 0; i < finder->p->np; i++) {
-        ptrdiff_t hid = offset[head[i]];
-        head[i] = hid;
-    }
-
-    fastpm_memory_free(finder->p->mem, offset);
+    fastpm_memory_free(finder->p->mem, ind);
 }
 
 void

--- a/libfastpm/fof.c
+++ b/libfastpm/fof.c
@@ -632,23 +632,7 @@ fastpm_fof_create_local_halos(FastPMFOFFinder * finder, FastPMStore * halos, siz
     halos->a_v = finder->p->a_v;
 
     MPI_Allreduce(MPI_IN_PLACE, &nhalos, 1, MPI_LONG, MPI_SUM, pm_comm(finder->pm));
-}
 
-/*
- * compute the attrs of the local halo segments based on local particles.
- * head : the hid of each particle; 
- * fofsave : the minid of each particle (unique label of each halo)
- *
- * if a halo has no local particles,  halos->mask[i] is set to 0.
- * if a halo has any local particles, and halos->mask[i] is set to 1.
- * */
-static void
-fastpm_fof_compute_local_halo_attrs (FastPMFOFFinder * finder, FastPMStore * halos, struct FastPMFOFData * fofsave, ptrdiff_t * head)
-{
-    FastPMStore h1[1];
-    fastpm_store_init(h1, 1, halos->attributes, FASTPM_MEMORY_HEAP);
-
-    /* */
     ptrdiff_t i;
     for(i = 0; i < halos->np; i++) {
         int d;
@@ -673,6 +657,24 @@ fastpm_fof_compute_local_halo_attrs (FastPMFOFFinder * finder, FastPMStore * hal
                 halos->q[i][d] = 0;
         }
     }
+}
+
+/*
+ * compute the attrs of the local halo segments based on local particles.
+ * head : the hid of each particle; 
+ * fofsave : the minid of each particle (unique label of each halo)
+ *
+ * if a halo has no local particles,  halos->mask[i] is set to 0.
+ * if a halo has any local particles, and halos->mask[i] is set to 1.
+ * */
+static void
+fastpm_fof_compute_local_halo_attrs (FastPMFOFFinder * finder, FastPMStore * halos, struct FastPMFOFData * fofsave, ptrdiff_t * head)
+{
+    FastPMStore h1[1];
+    fastpm_store_init(h1, 1, halos->attributes, FASTPM_MEMORY_HEAP);
+
+    /* */
+    ptrdiff_t i;
 
     /* set minid and task of the halo; all of the halo particles of the same minid needs to be reduced */
     for(i = 0; i < finder->p->np; i++) {

--- a/libfastpm/fof.c
+++ b/libfastpm/fof.c
@@ -601,7 +601,7 @@ fastpm_fof_execute(FastPMFOFFinder * finder, FastPMStore * halos)
     if(0 != fastpm_store_decompose(halos,
             (fastpm_store_target_func) FastPMTargetMinID, finder, comm)) {
 
-        fastpm_raise(-1, "out of space for halos decomposition.\n");
+        fastpm_raise(-1, "out of space sending halos by MinID.\n");
     }
 
     /* now head[i] is no longer the halo attribute of particle i. */
@@ -629,7 +629,7 @@ fastpm_fof_execute(FastPMFOFFinder * finder, FastPMStore * halos)
     /* decompose halos by task (return) */
     if (0 != fastpm_store_decompose(halos,
             (fastpm_store_target_func) FastPMTargetTask, finder, comm)) {
-        fastpm_raise(-1, "out of space for halos decomposition.\n");
+        fastpm_raise(-1, "out of space for gathering halos this shall never happen.\n");
     }
     /* local sort by id (restore the order) */
     fastpm_store_sort(halos, FastPMLocalSortByID);

--- a/libfastpm/fof.c
+++ b/libfastpm/fof.c
@@ -512,6 +512,8 @@ fastpm_fof_execute(FastPMFOFFinder * finder, FastPMStore * halos)
                     FASTPM_EVENT_STAGE_AFTER, (FastPMEvent*) event, finder);
 
     fastpm_memory_free(finder->p->mem, head);
+
+    fastpm_store_subsample(halos, halos->mask, halos);
 }
 
 static void

--- a/libfastpm/fof.c
+++ b/libfastpm/fof.c
@@ -246,6 +246,21 @@ _fof_global_merge(
 
     memset(fofcomm, 0, sizeof(fofcomm[0]) * (p->np + pgd->p->np));
 
+    /* initialize minid, used as a global tag of groups as we merge */
+    for(i = 0; i < p->np; i ++) {
+        fofsave[i].minid = p->id[i];
+        fofsave[i].task = finder->priv->ThisTask;
+    }
+    for(i = 0; i < pgd->p->np; i ++) {
+        fofsave[i + p->np].minid = pgd->p->id[i];
+        fofsave[i + p->np].task = -1;
+    }
+
+    /* reduce the minid of the head items according to the local connection. */
+
+    for(i = 0; i < p->np + pgd->p->np; i ++) {
+        _merge(&fofsave[i], &fofsave[head[i]]);
+    }
 
     /* at this point all items with head[i] = i have local minid and task */
 
@@ -312,7 +327,6 @@ _fof_global_merge(
 static void
 fastpm_fof_decompose(FastPMFOFFinder * finder, FastPMStore * p, PM * pm)
 {
-    ptrdiff_t i;
 
     /* initial decompose -- reduce number of ghosts */
 
@@ -365,22 +379,6 @@ fastpm_fof_decompose(FastPMFOFFinder * finder, FastPMStore * p, PM * pm)
                     sizeof(head[0]) * (p->np + pgd->p->np), FASTPM_MEMORY_STACK);
 
     _fof_local_find(finder, p, pgd, head, finder->linkinglength);
-
-    /* initialize minid, used as a global tag of groups as we merge */
-    for(i = 0; i < p->np; i ++) {
-        fofsave[i].minid = p->id[i];
-        fofsave[i].task = finder->priv->ThisTask;
-    }
-    for(i = 0; i < pgd->p->np; i ++) {
-        fofsave[i + p->np].minid = pgd->p->id[i];
-        fofsave[i + p->np].task = -1;
-    }
-
-    /* reduce the minid of the head items according to the local connection. */
-
-    for(i = 0; i < p->np + pgd->p->np; i ++) {
-        _merge(&fofsave[i], &fofsave[head[i]]);
-    }
 
     _fof_global_merge (finder, pgd, fofsave, head);
 

--- a/libfastpm/fof.c
+++ b/libfastpm/fof.c
@@ -843,11 +843,11 @@ fastpm_fof_convert_particle_to_halo(FastPMStore * p, ptrdiff_t i, FastPMStore * 
         if(halos->x)
             halos->x[hid][d] = p->x[i][d];
         if(halos->v)
-            halos->v[hid][d] += p->v[i][d];
+            halos->v[hid][d] = p->v[i][d];
         if(halos->dx1)
-            halos->dx1[hid][d] += p->dx1[i][d];
+            halos->dx1[hid][d] = p->dx1[i][d];
         if(halos->dx2)
-            halos->dx2[hid][d] += p->dx2[i][d];
+            halos->dx2[hid][d] = p->dx2[i][d];
         if(halos->q) {
             halos->q[hid][d] = q[d];
         }

--- a/libfastpm/fof.c
+++ b/libfastpm/fof.c
@@ -384,6 +384,8 @@ fastpm_fof_decompose(FastPMFOFFinder * finder, FastPMStore * p, PM * pm)
     fastpm_memory_free(p->mem, head);
     fastpm_memory_free(p->mem, fofsave);
 
+    pm_ghosts_free(pgd);
+
 
 #if 0
     BigFile bf = {0};
@@ -425,8 +427,6 @@ fastpm_fof_decompose(FastPMFOFFinder * finder, FastPMStore * p, PM * pm)
         );
 
     fastpm_memory_free(p->mem, fofcomm);
-
-    pm_ghosts_free(pgd);
 }
 
 static size_t

--- a/libfastpm/lightcone-smesh.c
+++ b/libfastpm/lightcone-smesh.c
@@ -243,7 +243,7 @@ fastpm_smesh_add_layers_healpix(FastPMSMesh * mesh,
 
     int j = 0;
     for(i = 1; i <= Na; i ++) {
-        if(nside[i] == nside[j] && i != Na) continue;
+        if(i != Na && nside[i] == nside[j]) continue;
         /* nside[i] != nside[j]; j ... i - 1 (inclusive) has the same nside */
         fastpm_info("Creating smesh for Nside = %04td arange %6.4f - %6.4f\n", nside[j], a[j], a[i - 1]);
         double *ra, *dec;

--- a/libfastpm/store.c
+++ b/libfastpm/store.c
@@ -66,6 +66,7 @@ static size_t pack(FastPMStore * p, ptrdiff_t index, void * buf, enum FastPMPack
     DISPATCH(PACK_LENGTH, length)
     DISPATCH(PACK_RDISP, rdisp)
     DISPATCH(PACK_VDISP, vdisp)
+    DISPATCH(PACK_RVDISP, rvdisp)
 
     /* components */
     DISPATCHC(PACK_ACC_X, acc, 0)
@@ -132,6 +133,7 @@ static void unpack(FastPMStore * p, ptrdiff_t index, void * buf, enum FastPMPack
     DISPATCH(PACK_LENGTH, length)
     DISPATCH(PACK_RDISP, rdisp)
     DISPATCH(PACK_VDISP, vdisp)
+    DISPATCH(PACK_RVDISP, rvdisp)
 
     DISPATCHC(PACK_ACC_X, acc, 0)
     DISPATCHC(PACK_ACC_Y, acc, 1)
@@ -358,6 +360,7 @@ fastpm_store_init_details(FastPMStore * p,
         DISPATCH(PACK_LENGTH, length);
         DISPATCH(PACK_RDISP, rdisp);
         DISPATCH(PACK_VDISP, vdisp);
+        DISPATCH(PACK_RVDISP, rvdisp);
 
         if(it == 0) {
             p->base = fastpm_memory_alloc_details(p->mem, "FastPMStore", size, loc, file, line);
@@ -434,6 +437,7 @@ void fastpm_store_permute(FastPMStore * p, int * ind)
     if(p->length) permute(p->length, p->np, sizeof(p->length[0]), ind);
     if(p->rdisp) permute(p->rdisp, p->np, sizeof(p->rdisp[0]), ind);
     if(p->vdisp) permute(p->vdisp, p->np, sizeof(p->vdisp[0]), ind);
+    if(p->rvdisp) permute(p->rvdisp, p->np, sizeof(p->rvdisp[0]), ind);
 }
 
 

--- a/libfastpm/store.c
+++ b/libfastpm/store.c
@@ -64,6 +64,8 @@ static size_t pack(FastPMStore * p, ptrdiff_t index, void * buf, enum FastPMPack
     DISPATCH(PACK_MASK, mask)
     DISPATCH(PACK_FOF, fof)
     DISPATCH(PACK_LENGTH, length)
+    DISPATCH(PACK_RDISP, rdisp)
+    DISPATCH(PACK_VDISP, vdisp)
 
     /* components */
     DISPATCHC(PACK_ACC_X, acc, 0)
@@ -128,6 +130,8 @@ static void unpack(FastPMStore * p, ptrdiff_t index, void * buf, enum FastPMPack
     DISPATCH(PACK_MASK, mask)
     DISPATCH(PACK_FOF, fof)
     DISPATCH(PACK_LENGTH, length)
+    DISPATCH(PACK_RDISP, rdisp)
+    DISPATCH(PACK_VDISP, vdisp)
 
     DISPATCHC(PACK_ACC_X, acc, 0)
     DISPATCHC(PACK_ACC_Y, acc, 1)
@@ -352,6 +356,8 @@ fastpm_store_init_details(FastPMStore * p,
         SIZEIT(mask, PACK_MASK);
         SIZEIT(fof , PACK_FOF);
         SIZEIT(length, PACK_LENGTH);
+        SIZEIT(rdisp, PACK_RDISP);
+        SIZEIT(vdisp, PACK_VDISP);
 
         if(it == 0) {
             p->base = fastpm_memory_alloc_details(p->mem, "FastPMStore", size, loc, file, line);
@@ -426,6 +432,8 @@ void fastpm_store_permute(FastPMStore * p, int * ind)
     if(p->mask) permute(p->mask, p->np, sizeof(p->mask[0]), ind);
     if(p->fof) permute(p->fof, p->np, sizeof(p->fof[0]), ind);
     if(p->length) permute(p->length, p->np, sizeof(p->length[0]), ind);
+    if(p->rdisp) permute(p->rdisp, p->np, sizeof(p->rdisp[0]), ind);
+    if(p->vdisp) permute(p->vdisp, p->np, sizeof(p->vdisp[0]), ind);
 }
 
 
@@ -784,6 +792,8 @@ _fastpm_store_copy(FastPMStore * p, ptrdiff_t start, FastPMStore * po, ptrdiff_t
     if(po->mask) memcpy(&po->mask[offset], &p->mask[start], sizeof(p->mask[0]) * ncopy);
     if(po->fof) memcpy(&po->fof[offset], &p->fof[start], sizeof(p->fof[0]) * ncopy);
     if(po->length) memcpy(&po->length[offset], &p->length[start], sizeof(p->length[0]) * ncopy);
+    if(po->rdisp) memcpy(&po->rdisp[offset], &p->rdisp[start], sizeof(p->rdisp[0]) * ncopy);
+    if(po->vdisp) memcpy(&po->vdisp[offset], &p->vdisp[start], sizeof(p->vdisp[0]) * ncopy);
 
     po->np = offset + ncopy;
     po->a_x = p->a_x;
@@ -868,6 +878,8 @@ fastpm_store_subsample(FastPMStore * p, uint8_t * mask, FastPMStore * po)
             if(po->mask) po->mask[j] = p->mask[i];
             if(po->fof) po->fof[j] = p->fof[i];
             if(po->length) po->length[j] = p->length[i];
+            if(po->rdisp) memcpy(po->rdisp[j], p->rdisp[i], sizeof(p->rdisp[0][0]) * 6);
+            if(po->vdisp) memcpy(po->vdisp[j], p->vdisp[i], sizeof(p->vdisp[0][0]) * 6);
         }
         j ++;
     }

--- a/libfastpm/store.c
+++ b/libfastpm/store.c
@@ -51,19 +51,19 @@ static size_t pack(FastPMStore * p, ptrdiff_t index, void * buf, enum FastPMPack
     size_t s = 0;
     char * ptr = (char*) buf;
     DISPATCH(PACK_POS, x)
+    DISPATCH(PACK_Q, q)
     DISPATCH(PACK_VEL, v)
-    DISPATCH(PACK_ID, id)
-    DISPATCH(PACK_MASK, mask)
-    DISPATCH(PACK_LENGTH, length)
-    DISPATCH(PACK_DENSITY, rho)
-    DISPATCH(PACK_POTENTIAL, potential)
+    DISPATCH(PACK_ACC, acc)
     DISPATCH(PACK_DX1, dx1)
     DISPATCH(PACK_DX2, dx2)
-    DISPATCH(PACK_Q, q)
     DISPATCH(PACK_AEMIT, aemit)
-    DISPATCH(PACK_ACC, acc)
+    DISPATCH(PACK_DENSITY, rho)
+    DISPATCH(PACK_POTENTIAL, potential)
     DISPATCH(PACK_TIDAL, tidal)
+    DISPATCH(PACK_ID, id)
+    DISPATCH(PACK_MASK, mask)
     DISPATCH(PACK_FOF, fof)
+    DISPATCH(PACK_LENGTH, length)
 
     /* components */
     DISPATCHC(PACK_ACC_X, acc, 0)
@@ -115,19 +115,19 @@ static void unpack(FastPMStore * p, ptrdiff_t index, void * buf, enum FastPMPack
         } \
     }
     DISPATCH(PACK_POS, x)
+    DISPATCH(PACK_Q, q)
     DISPATCH(PACK_VEL, v)
-    DISPATCH(PACK_ID, id)
-    DISPATCH(PACK_MASK, mask)
-    DISPATCH(PACK_LENGTH, length)
-    DISPATCH(PACK_DENSITY, rho)
-    DISPATCH(PACK_POTENTIAL, potential)
+    DISPATCH(PACK_ACC, acc)
     DISPATCH(PACK_DX1, dx1)
     DISPATCH(PACK_DX2, dx2)
-    DISPATCH(PACK_Q, q)
     DISPATCH(PACK_AEMIT, aemit)
-    DISPATCH(PACK_ACC, acc)
+    DISPATCH(PACK_DENSITY, rho)
+    DISPATCH(PACK_POTENTIAL, potential)
     DISPATCH(PACK_TIDAL, tidal)
+    DISPATCH(PACK_ID, id)
+    DISPATCH(PACK_MASK, mask)
     DISPATCH(PACK_FOF, fof)
+    DISPATCH(PACK_LENGTH, length)
 
     DISPATCHC(PACK_ACC_X, acc, 0)
     DISPATCHC(PACK_ACC_Y, acc, 1)
@@ -338,12 +338,9 @@ fastpm_store_init_details(FastPMStore * p,
     ptrdiff_t size = 0;
     ptrdiff_t offset = 0;
     for(it = 0; it < 2; it ++) {
-        SIZEIT(q, PACK_Q);
         SIZEIT(x, PACK_POS);
+        SIZEIT(q, PACK_Q);
         SIZEIT(v, PACK_VEL);
-        SIZEIT(id, PACK_ID);
-        SIZEIT(length, PACK_LENGTH);
-        SIZEIT(fof , PACK_FOF);
         SIZEIT(acc, PACK_ACC);
         SIZEIT(dx1, PACK_DX1);
         SIZEIT(dx2, PACK_DX2);
@@ -351,7 +348,10 @@ fastpm_store_init_details(FastPMStore * p,
         SIZEIT(rho, PACK_DENSITY);
         SIZEIT(potential, PACK_POTENTIAL);
         SIZEIT(tidal, PACK_TIDAL);
+        SIZEIT(id, PACK_ID);
         SIZEIT(mask, PACK_MASK);
+        SIZEIT(fof , PACK_FOF);
+        SIZEIT(length, PACK_LENGTH);
 
         if(it == 0) {
             p->base = fastpm_memory_alloc_details(p->mem, "FastPMStore", size, loc, file, line);
@@ -410,47 +410,54 @@ static void permute(void * data, int np, size_t elsize, int * ind) {
     free(tmp);
 }
 
-static void fastpm_store_permute(FastPMStore * p, int * ind) {
-    if(p->x)
-        permute(p->x, p->np, sizeof(p->x[0]), ind);
-    if(p->v)
-        permute(p->v, p->np, sizeof(p->v[0]), ind);
-    if(p->id)
-        permute(p->id, p->np, sizeof(p->id[0]), ind);
-    if(p->mask)
-        permute(p->mask, p->np, sizeof(p->mask[0]), ind);
-    if(p->fof)
-        permute(p->fof, p->np, sizeof(p->fof[0]), ind);
-    if(p->potential)
-        permute(p->potential, p->np, sizeof(p->potential[0]), ind);
-    if(p->tidal)
-        permute(p->tidal, p->np, sizeof(p->tidal[0]), ind);
-    if(p->aemit)
-        permute(p->aemit, p->np, sizeof(p->aemit[0]), ind);
-    if(p->q)
-        permute(p->q, p->np, sizeof(p->q[0]), ind);
-    if(p->acc)
-        permute(p->acc, p->np, sizeof(p->acc[0]), ind);
-    if(p->dx1)
-        permute(p->dx1, p->np, sizeof(p->dx1[0]), ind);
-    if(p->dx2)
-        permute(p->dx2, p->np, sizeof(p->dx2[0]), ind);
+void fastpm_store_permute(FastPMStore * p, int * ind)
+{
+    if(p->x) permute(p->x, p->np, sizeof(p->x[0]), ind);
+    if(p->q) permute(p->q, p->np, sizeof(p->q[0]), ind);
+    if(p->v) permute(p->v, p->np, sizeof(p->v[0]), ind);
+    if(p->acc) permute(p->acc, p->np, sizeof(p->acc[0]), ind);
+    if(p->dx1) permute(p->dx1, p->np, sizeof(p->dx1[0]), ind);
+    if(p->dx2) permute(p->dx2, p->np, sizeof(p->dx2[0]), ind);
+    if(p->aemit) permute(p->aemit, p->np, sizeof(p->aemit[0]), ind);
+    if(p->rho) permute(p->rho, p->np, sizeof(p->rho[0]), ind);
+    if(p->potential) permute(p->potential, p->np, sizeof(p->potential[0]), ind);
+    if(p->tidal) permute(p->tidal, p->np, sizeof(p->tidal[0]), ind);
+    if(p->id) permute(p->id, p->np, sizeof(p->id[0]), ind);
+    if(p->mask) permute(p->mask, p->np, sizeof(p->mask[0]), ind);
+    if(p->fof) permute(p->fof, p->np, sizeof(p->fof[0]), ind);
+    if(p->length) permute(p->length, p->np, sizeof(p->length[0]), ind);
 }
 
-static int * __sort_by_id_arg;
-static FastPMStore *  __sort_by_id_p;
+
+static FastPMStore *  _fastpm_store_sort_store;
+static int (*_fastpm_store_sort_cmp_func)(const int i1, const int i2, FastPMStore * p);
+
 int _sort_by_id_cmpfunc(const void * p1, const void * p2)
 {
     const int * i1 = (const int*) p1;
     const int * i2 = (const int*) p2;
-    
-    int v1 = (__sort_by_id_p->id[*i1] < __sort_by_id_p->id[*i2]);
-    int v2 = (__sort_by_id_p->id[*i1] > __sort_by_id_p->id[*i2]);
+
+    return _fastpm_store_sort_cmp_func(*i1, *i2, _fastpm_store_sort_store);
+}
+
+int
+FastPMLocalSortByID(const int i1,
+                    const int i2,
+                    FastPMStore * p)
+{
+    int v1 = (p->id[i1] < p->id[i2]);
+    int v2 = (p->id[i1] > p->id[i2]);
 
     return v2 - v1;
 }
 
-void fastpm_store_sort_by_id(FastPMStore * p)
+/* sort a store locally with in the MPI rank. 
+ *
+ * cmp_func is called with three arguments.
+ * */
+void
+fastpm_store_sort(FastPMStore * p,
+        int (*cmp_func)(const int i1, const int i2, FastPMStore * p))
 {
     int * arg = fastpm_memory_alloc(p->mem, "Temp", sizeof(int) * p->np, FASTPM_MEMORY_HEAP);
     int i;
@@ -458,8 +465,8 @@ void fastpm_store_sort_by_id(FastPMStore * p)
         arg[i] = i;
     }
     /* FIXME: copy some version of qsort_r */
-    __sort_by_id_arg = arg;
-    __sort_by_id_p = p;
+    _fastpm_store_sort_store = p;
+    _fastpm_store_sort_cmp_func = cmp_func;
     qsort(arg, p->np, sizeof(arg[0]), _sort_by_id_cmpfunc);
     fastpm_store_permute(p, arg);
     fastpm_memory_free(p->mem, arg);
@@ -765,12 +772,14 @@ _fastpm_store_copy(FastPMStore * p, ptrdiff_t start, FastPMStore * po, ptrdiff_t
     if(po->acc) memcpy(&po->acc[offset], &p->acc[start], sizeof(p->acc[0][0]) * 3 * ncopy);
     if(po->dx1) memcpy(&po->dx1[offset], &p->dx1[start], sizeof(p->dx1[0][0]) * 3 * ncopy);
     if(po->dx2) memcpy(&po->dx2[offset], &p->dx2[start], sizeof(p->dx2[0][0]) * 3 * ncopy);
+    if(po->aemit) memcpy(&po->aemit[offset], &p->aemit[start], sizeof(p->aemit[0]) * ncopy);
+    if(po->rho) memcpy(&po->rho[offset], &p->rho[start], sizeof(p->potential[0]) * ncopy);
+    if(po->potential) memcpy(&po->potential[offset], &p->potential[start], sizeof(p->potential[0]) * ncopy);
+    if(po->tidal) memcpy(&po->tidal[offset], &p->tidal[start], sizeof(p->tidal[0]) * ncopy);
     if(po->id) memcpy(&po->id[offset], &p->id[start], sizeof(p->id[0]) * ncopy);
     if(po->mask) memcpy(&po->mask[offset], &p->mask[start], sizeof(p->mask[0]) * ncopy);
-    if(po->aemit) memcpy(&po->aemit[offset], &p->aemit[start], sizeof(p->aemit[0]) * ncopy);
-    if(po->potential) memcpy(&po->potential[offset], &p->potential[start], sizeof(p->potential[0]) * ncopy);
-    if(po->rho) memcpy(&po->rho[offset], &p->rho[start], sizeof(p->potential[0]) * ncopy);
-    if(po->tidal) memcpy(&po->tidal[offset], &p->tidal[start], sizeof(p->tidal[0]) * ncopy);
+    if(po->fof) memcpy(&po->fof[offset], &p->fof[start], sizeof(p->fof[0]) * ncopy);
+    if(po->length) memcpy(&po->length[offset], &p->length[start], sizeof(p->length[0]) * ncopy);
 
     po->np = offset + ncopy;
     po->a_x = p->a_x;
@@ -847,11 +856,14 @@ fastpm_store_subsample(FastPMStore * p, uint8_t * mask, FastPMStore * po)
             if(po->acc) memcpy(po->acc[j], p->acc[i], sizeof(p->acc[0][0]) * 3);
             if(po->dx1) memcpy(po->dx1[j], p->dx1[i], sizeof(p->dx1[0][0]) * 3);
             if(po->dx2) memcpy(po->dx2[j], p->dx2[i], sizeof(p->dx2[0][0]) * 3);
-            if(po->id) po->id[j] = p->id[i];
-            if(po->mask) po->mask[j] = p->mask[i];
             if(po->aemit) po->aemit[j] = p->aemit[i];
+            if(po->rho) po->rho[j] = p->rho[i];
             if(po->potential) po->potential[j] = p->potential[i];
             if(po->tidal) memcpy(po->tidal[j], p->tidal[i], sizeof(p->tidal[0][0]) * 6);
+            if(po->id) po->id[j] = p->id[i];
+            if(po->mask) po->mask[j] = p->mask[i];
+            if(po->fof) po->fof[j] = p->fof[i];
+            if(po->length) po->length[j] = p->length[i];
         }
         j ++;
     }

--- a/libfastpm/store.c
+++ b/libfastpm/store.c
@@ -575,7 +575,7 @@ fastpm_store_decompose(FastPMStore * p,
     size_t Nrecv = cumsum(recvoffset, recvcount, NTask);
     size_t elsize = p->pack(p, 0, NULL, p->attributes);
 
-    size_t neededsize = p->np + Nrecv - Nsend;
+    volatile size_t neededsize = p->np + Nrecv - Nsend;
 
     if(neededsize > p->np_upper) {
         fastpm_ilog(INFO, "Need %td particles on rank %d; %td allocated\n", neededsize, ThisTask, p->np_upper);

--- a/libfastpmio/io.c
+++ b/libfastpmio/io.c
@@ -191,6 +191,7 @@ write_snapshot_data(FastPMStore * p,
 
     MPI_Allreduce(MPI_IN_PLACE, &size, 1, MPI_LONG, MPI_SUM, comm);
 
+
     int Nfile = size / (32 * 1024 * 1024);
 
     if(Nfile < 1) Nfile = 1;
@@ -201,6 +202,8 @@ write_snapshot_data(FastPMStore * p,
      * */
 
     if(Nwriters > Nfile * 8) Nwriters = Nfile * 8;
+
+    fastpm_info("Writing %ld objects to %d files with %d writers\n", size, Nfile, Nwriters);
 
     struct {
         char * name;
@@ -298,6 +301,8 @@ write_snapshot(FastPMSolver * fastpm, FastPMStore * p,
 
     write_snapshot_header(fastpm, p, &bf, comm);
 
+    fastpm_info("Writring a catalog to %s [%s] with\n", filebase, dataset);
+
     write_snapshot_data(p,  Nwriters, 0, &bf, dataset, comm);
 
     big_file_mpi_close(&bf, comm);
@@ -331,6 +336,7 @@ append_snapshot(FastPMSolver * fastpm, FastPMStore * p,
         fastpm_raise(-1, "Failed to create the file: %s\n", big_file_get_error_message());
     }
 
+    fastpm_info("Appending a catalog to %s [%s]\n", filebase, dataset);
     write_snapshot_data(p, Nwriters, 1, &bf, dataset, comm);
 
     big_file_mpi_close(&bf, comm);

--- a/libfastpmio/io.c
+++ b/libfastpmio/io.c
@@ -226,6 +226,8 @@ write_snapshot_data(FastPMStore * p,
         {"Length", p->length, "i4", 4, 1, "i4"},
         {"MinID",p->fof?&(p->fof[0].minid):NULL, "i8", sizeof(p->fof[0]), 1, "i8"},
         {"Task", p->fof?&(p->fof[0].task):NULL, "i4", sizeof(p->fof[0]), 1, "i4"},
+        {"Rdisp",p->rdisp, "f4", sizeof(p->rdisp[0][0]), 6, "f4"},
+        {"Vdisp", p->vdisp, "f4", sizeof(p->vdisp[0][0]), 6, "f4"},
         {NULL, },
     };
     if (!append) {

--- a/libfastpmio/io.c
+++ b/libfastpmio/io.c
@@ -228,6 +228,7 @@ write_snapshot_data(FastPMStore * p,
         {"Task", p->fof?&(p->fof[0].task):NULL, "i4", sizeof(p->fof[0]), 1, "i4"},
         {"Rdisp",p->rdisp, "f4", sizeof(p->rdisp[0][0]), 6, "f4"},
         {"Vdisp", p->vdisp, "f4", sizeof(p->vdisp[0][0]), 6, "f4"},
+        {"RVdisp", p->rvdisp, "f4", sizeof(p->rvdisp[0][0]), 9, "f4"},
         {NULL, },
     };
     if (!append) {

--- a/src/fastpm.c
+++ b/src/fastpm.c
@@ -1031,7 +1031,7 @@ _halos_ready (FastPMFOFFinder * finder,
 
     ptrdiff_t i;
 
-    uint8_t * halos_mask = malloc(halos->np);
+    uint8_t * halos_established = malloc(halos->np);
     fastpm_info("halos_ready sees %td halos\n", halos->np);
     for(i = 0; i < halos->np; i ++) {
         double r = fastpm_lc_distance(lc, halos->x[i]);
@@ -1041,10 +1041,11 @@ _halos_ready (FastPMFOFFinder * finder,
 
         /* only keep reliable halos */
         if(r > rmin + halosize * 0.5) {
-            halos_mask[i] = 1;
+            halos_established[i] = 1;
         } else {
-            halos_mask[i] = 0;
+            halos_established[i] = 0;
         }
+        halos->mask[i] &= halos_established[i];
     }
 
     for(i = 0; i < p->np; i ++) {
@@ -1057,15 +1058,14 @@ _halos_ready (FastPMFOFFinder * finder,
             /* near the tail of the lightcone, do not keep those formed reliable halos */
             if(hid >= 0) {
                 /* particles in unreliable halos, keep them */
-                keep_for_tail[i] = !halos_mask[hid];
+                keep_for_tail[i] = !halos_established[hid];
             } else {
                 /* not in halos, keep them too */
                 keep_for_tail[i] = 1;
             }
         }
-        halos->mask[hid] &= halos_mask[hid];
     }
-    free(halos_mask);
+    free(halos_established);
 }
 
 

--- a/src/fastpm.c
+++ b/src/fastpm.c
@@ -1012,9 +1012,13 @@ _halos_ready (FastPMFOFFinder * finder,
     ptrdiff_t i;
 
     uint8_t * halos_mask = malloc(halos->np);
-
+    fastpm_info("halos_ready sees %td halos\n", halos->np);
     for(i = 0; i < halos->np; i ++) {
         double r = fastpm_lc_distance(lc, halos->x[i]);
+
+        /* this shall not happen */
+        if (halos->length[i] < finder->nmin) abort();
+
         /* only keep reliable halos */
         if(r > rmin + halosize * 0.5) {
             halos_mask[i] = 1;

--- a/src/fastpm.c
+++ b/src/fastpm.c
@@ -367,8 +367,28 @@ prepare_ic(FastPMSolver * fastpm, Parameters * prr, MPI_Comm comm)
 {
     /* we may need a read gadget ic here too */
     if(CONF(prr, read_runpbic)) {
+        FastPMStore * p = fastpm->p;
+        int temp_dx1 = 0;
+        int temp_dx2 = 0;
+        if(p->dx1 == NULL) {
+            p->dx1 = fastpm_memory_alloc(p->mem, "DX1", sizeof(p->dx1[0]) * p->np_upper, FASTPM_MEMORY_STACK);
+            temp_dx1 = 1;
+        }
+        if(p->dx2 == NULL) {
+            p->dx2 = fastpm_memory_alloc(p->mem, "DX2", sizeof(p->dx2[0]) * p->np_upper, FASTPM_MEMORY_STACK);
+            temp_dx2 = 1;
+        }
+
         read_runpb_ic(fastpm, fastpm->p, CONF(prr, read_runpbic));
         fastpm_solver_setup_ic(fastpm, NULL, CONF(prr, time_step)[0]);
+        if(temp_dx2) {
+            fastpm_memory_free(p->mem, p->dx2);
+            p->dx2 = NULL;
+        }
+        if(temp_dx1) {
+            fastpm_memory_free(p->mem, p->dx1);
+            p->dx1 = NULL;
+        }
         return;
     } 
 

--- a/src/runpb.c
+++ b/src/runpb.c
@@ -118,17 +118,6 @@ read_runpb_ic(FastPMSolver * fastpm, FastPMStore * p, const char * filename)
 
     fastpm_info("Ntot = %td aa=%g\n", Ntot, aa);
 
-    int temp_dx1 = 0;
-    int temp_dx2 = 0;
-    if(p->dx1 == NULL) {
-        p->dx1 = fastpm_memory_alloc(p->mem, "DX1", sizeof(p->dx1[0]) * p->np_upper, FASTPM_MEMORY_STACK);
-        temp_dx1 = 1;
-    }
-    if(p->dx2 == NULL) {
-        p->dx2 = fastpm_memory_alloc(p->mem, "DX2", sizeof(p->dx2[0]) * p->np_upper, FASTPM_MEMORY_STACK);
-        temp_dx2 = 1;
-    }
-
 
     NcumFile = malloc(sizeof(size_t) * Nfile);
     NcumFile[0] = 0;
@@ -314,14 +303,6 @@ read_runpb_ic(FastPMSolver * fastpm, FastPMStore * p, const char * filename)
     free(NperFile);
     free(scratch);
 
-    if(temp_dx2) {
-        fastpm_memory_free(p->mem, p->dx2);
-        p->dx2 = NULL;
-    }
-    if(temp_dx1) {
-        fastpm_memory_free(p->mem, p->dx1);
-        p->dx1 = NULL;
-    }
     return 0;
 }
 

--- a/src/runpb.c
+++ b/src/runpb.c
@@ -245,6 +245,13 @@ read_runpb_ic(FastPMSolver * fastpm, FastPMStore * p, const char * filename)
 
     int64_t strides[] = {fastpm->config->nc * fastpm->config->nc, fastpm->config->nc, 1};
 
+    int d;
+    for(d = 0; d < 3; d++){
+        p->q_strides[d] = strides[d];
+        p->q_scale[d] = (1.0 * fastpm->config->boxsize) / fastpm->config->nc;
+        p->q_shift[d] = 0.5 * (1.0 * fastpm->config->boxsize) / fastpm->config->nc;
+    }
+
     /* RUN PB ic global shifting */
     const double offset0 = 0.5 * 1.0 / fastpm->config->nc;
     double dx1disp[3] = {0};
@@ -288,7 +295,6 @@ read_runpb_ic(FastPMSolver * fastpm, FastPMStore * p, const char * filename)
         }
     }
 
-    int d;
     MPI_Allreduce(MPI_IN_PLACE, dx1disp, 3, MPI_DOUBLE, MPI_SUM, comm);
     MPI_Allreduce(MPI_IN_PLACE, dx2disp, 3, MPI_DOUBLE, MPI_SUM, comm);
     for(d =0; d < 3; d++) {

--- a/tests/nbodykit.lua
+++ b/tests/nbodykit.lua
@@ -12,7 +12,7 @@ boxsize = 384.0
 -- time_step = linspace(0.01, 1.0, 10)
 time_step = linspace(0.1, 1, 2)
 
-output_redshifts= {0.0}  -- redshifts of output
+output_redshifts= {0.5, 0.0}  -- redshifts of output
 
 -- Cosmology --
 omega_m = 0.307494


### PR DESCRIPTION
Decompose the halos rather than the particles:

- run KDTree once rather than twice
- less communication (only send halo segments, once)