### PR TITLE
Change linspace to be compatible with numpy.

### DIFF
--- a/src/lua-runtime-fastpm.lua
+++ b/src/lua-runtime-fastpm.lua
@@ -194,7 +194,7 @@ schema.declare{name='lc_glmatrix',     type='array:number',
 
 schema.declare{name='za',                      type='boolean', default=false, help='use ZA initial condition not 2LPT'}
 
-schema.declare{name='kernel_type',             type='enum', default="3_4", help='Force kernel; very little effect.'}
+schema.declare{name='kernel_type',             type='enum', default="gadget", help='Force kernel; very little effect.'}
 schema.kernel_type.choices = {
     ['3_4'] = 'FASTPM_KERNEL_3_4',
     ['5_4'] = 'FASTPM_KERNEL_5_4',

--- a/src/lua-runtime-fastpm.lua
+++ b/src/lua-runtime-fastpm.lua
@@ -264,8 +264,7 @@ function fastpm.outerproduct(a, b, c)
 end
 
 function fastpm.linspace(a, e, N, endpoint)
--- Similar to numpy.linspace, but always append the end
--- point to the result, returning N + 1 elements.
+-- Similar to numpy.linspace always append the end
 --
 -- https://mail.scipy.org/pipermail/numpy-discussion/2016-February/075065.html
     if endpoint == nil then
@@ -275,24 +274,24 @@ function fastpm.linspace(a, e, N, endpoint)
     local r = {}
 
     if endpoint then
-        N1 = N + 1
+        N1 = N - 1
     else
         N1 = N
     end
 
-    for i=1,N1 do
-        r[i] = 1.0 * (e - a) * (i - 1) / N + a
+    for i=1,N do
+        r[i] = 1.0 * (e - a) * (i - 1) / N1 + a
     end
 
     if endpoint then
-        r[N1] = e
+        r[N] = e
     end
     return r
 end
 
 function fastpm.logspace(a, e, N)
 -- a and end are in log10.
--- Returns N+1 elements, including e.
+-- Returns N elements, including e.
     local r
     r = fastpm.linspace(a, e, N)
     for i, j in pairs(r) do

--- a/tests/nbodykit.lua
+++ b/tests/nbodykit.lua
@@ -10,7 +10,7 @@ boxsize = 384.0
 -- time_step = linspace(0.025, 1.0, 39)
 -- logspace: Uniform time steps in loga
 -- time_step = linspace(0.01, 1.0, 10)
-time_step = linspace(0.1, 1, 2)
+time_step = linspace(0.1, 1, 3)
 
 output_redshifts= {0.5, 0.0}  -- redshifts of output
 

--- a/tests/ncdm.lua
+++ b/tests/ncdm.lua
@@ -8,7 +8,7 @@ boxsize = 1000
 -------- Time Sequence ----
 -- linspace: Uniform time steps in a
 -- logspace: Uniform time steps in loga
-time_step = linspace(0.01,0.02,20)
+time_step = linspace(0.01,0.02, 21)
 
 output_redshifts= {99.0, 49.}  -- redshifts of output
 


### PR DESCRIPTION
1. This PR breaks backward compatibility of parameter files. They will run 1 fewer time step.

But it means fastpm-python and fastpm have the same definition of time steps.

2. The default force kernel is set to 'gadget', which is the same kernel used in fastpm-python.

It is gadget without short range split and without CIC deconvolution. This is somewhat inconsistent with the fastpm paper's description, which was not clear whether the deconv was used.