### PR TITLE
Add a test case for the lightcone.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ script:
     - pushd tests
     - bash runtests.sh
     - bash run-test-nbodykit.sh
+    - bash run-test-lightcone.sh
     - popd
 
 # after_success: ./update-ghpages.sh

--- a/api/fastpm/store.h
+++ b/api/fastpm/store.h
@@ -260,7 +260,7 @@ void
 fastpm_store_take(FastPMStore * in, ptrdiff_t i, FastPMStore * out, ptrdiff_t j);
 
 void
-fastpm_store_append(FastPMStore * in, FastPMStore * out);
+fastpm_store_extend(FastPMStore * p, FastPMStore * extra);
 
 void fastpm_store_get_position(FastPMStore * p, ptrdiff_t index, double pos[3]);
 void fastpm_store_get_lagrangian_position(FastPMStore * p, ptrdiff_t index, double pos[3]);

--- a/libfastpm/lightcone-usmesh.c
+++ b/libfastpm/lightcone-usmesh.c
@@ -328,8 +328,8 @@ fastpm_usmesh_intersect_tile(FastPMUSMesh * mesh, double * tileshift,
             #pragma omp atomic capture
                 next = pout->np++;
 
-            if(next == pout->np_upper) {
-                fastpm_raise(-1, "Too many particles in the light cone; limit = %td\n", pout->np_upper);
+            if(next >= pout->np_upper) {
+                continue;
             }
 
             /* copy the position if desired */
@@ -376,6 +376,9 @@ fastpm_usmesh_intersect_tile(FastPMUSMesh * mesh, double * tileshift,
         fastpm_horizon_solve_end(params.context);
     }
 
+    if(pout->np >= pout->np_upper) {
+        fastpm_raise(-1, "Too many particles in the light cone; limit = %td, wanted = %td\n", pout->np_upper, pout->np);
+    }
     return 0;
 }
 

--- a/libfastpm/store.c
+++ b/libfastpm/store.c
@@ -908,10 +908,11 @@ fastpm_store_take(FastPMStore * p, ptrdiff_t i, FastPMStore * po, ptrdiff_t j)
     _fastpm_store_copy(p, i, po, j, 1);
 }
 
+/* extends p by extra. */
 void
-fastpm_store_append(FastPMStore * p, FastPMStore * po)
+fastpm_store_extend(FastPMStore * p, FastPMStore * extra)
 {
-    _fastpm_store_copy(p, 0, po, po->np, p->np);
+    _fastpm_store_copy(extra, 0, p, p->np, extra->np);
 }
 
 void

--- a/src/fastpm.c
+++ b/src/fastpm.c
@@ -1072,7 +1072,7 @@ run_usmesh_fof(FastPMSolver * fastpm,
     for(i = 0; i < tail->np; i ++) {
         tail->mask[i] = 0;
     }
-    fastpm_store_append(tail, lcevent->p);
+    fastpm_store_extend(lcevent->p, tail);
     fastpm_store_destroy(tail);
 
     /* FIXME: register event to mask out particles*/

--- a/src/fastpm.c
+++ b/src/fastpm.c
@@ -1257,7 +1257,7 @@ take_a_snapshot(FastPMSolver * fastpm, RunData * prr)
     return 0;
 }
 
-static int 
+static int
 check_lightcone(FastPMSolver * fastpm, FastPMInterpolationEvent * event, FastPMUSMesh * usmesh)
 {
     fastpm_usmesh_intersect(usmesh, event->drift, event->kick, event->whence, fastpm->comm);
@@ -1266,7 +1266,7 @@ check_lightcone(FastPMSolver * fastpm, FastPMInterpolationEvent * event, FastPMU
 
     MPI_Allreduce(MPI_IN_PLACE, &np, 1, MPI_LONG, MPI_SUM, fastpm->comm);
 
-    fastpm_info("Total number of particles in light cone: %ld\n", np);
+    fastpm_info("Total number of particles in light cone slice: %ld\n", np);
 
     return 0;
 }

--- a/tests/lightcone.lua
+++ b/tests/lightcone.lua
@@ -10,9 +10,9 @@ boxsize = 512
 -- time_step = linspace(0.025, 1.0, 39)
 -- logspace: Uniform time steps in loga
 -- time_step = linspace(0.01, 1.0, 10)
-time_step = linspace(0.1, 1, 3)
+time_step = linspace(0.1, 1, 8)
 
-output_redshifts= {1.0, 0.0}  -- redshifts of output
+output_redshifts= {0.0}  -- redshifts of output
 compute_potential = true
 compute_tidal = true
 
@@ -31,13 +31,13 @@ force_mode = "fastpm"
 -- force_mode = "cola"
 pm_nc_factor = 2            -- Particle Mesh grid pm_nc_factor*nc per dimension in the beginning
 
-np_alloc_factor= 2.0      -- Amount of memory allocated for particle
+np_alloc_factor = 2.0      -- Amount of memory allocated for particle
 
 -------- Output ---------------
 
 -- Dark matter particle outputs (all particles)
 -- write_runpb_snapshot= "nbodykit/tpm"
-write_snapshot = "lightcone/fastpm" 
+write_snapshot = "lightcone/fastpm"
 write_fof = "lightcone/fof"
 -- 1d power spectrum (raw), without shotnoise correction
 
@@ -60,15 +60,10 @@ lc_fov = 360
 --]]
 
 -- lc_glmatrix = fastpm.translation(-128, -128, -128)
-lc_smesh_max_nside= 32
 lc_amin = 0.1
 lc_amax = 1.0
-lc_smesh_fraction = 1.0
 
--- lc_smesh_use_linear_fields = true
-
-lc_usmesh_tiles = fastpm.outerproduct({-1, 0}, {-1, 0}, {-1, 0})
-lc_usmesh_fof_padding = 10.0
-lc_usmesh_alloc_factor = 10.0
 lc_write_usmesh = "lightcone/usmesh"
-lc_write_smesh = "lightcone/smesh"
+lc_usmesh_tiles = fastpm.outerproduct({-1, 0}, {-1, 0}, {-1, 0})
+lc_usmesh_fof_padding = 20.0
+lc_usmesh_alloc_factor = 2.0

--- a/tests/run-test-lightcone.sh
+++ b/tests/run-test-lightcone.sh
@@ -1,0 +1,16 @@
+#! /bin/bash
+
+source testfunctions.sh
+
+FASTPM="`dirname $0`/../src/fastpm -T 1"
+log=`mktemp`
+
+log=lclog
+assert_success "mpirun -n 4 $FASTPM lightcone.lua > $log"
+
+echo "---- Validating the log output -------"
+assert_file_contains $log 'Writing 1607204 objects.'
+assert_file_contains $log 'Writing 4983 objects.'
+assert_file_contains $log 'sigma8.*0.815897'
+
+report_test_status

--- a/tests/run-test-lightcone.sh
+++ b/tests/run-test-lightcone.sh
@@ -5,10 +5,26 @@ source testfunctions.sh
 FASTPM="`dirname $0`/../src/fastpm -T 1"
 log=`mktemp`
 
-log=lclog
 assert_success "mpirun -n 4 $FASTPM lightcone.lua > $log"
 
 echo "---- Validating the log output -------"
+assert_file_contains $log 'Total number of particles in light cone slice: 3083305'
+assert_file_contains $log 'Total number of particles in light cone slice: 2233892'
+assert_file_contains $log 'Total number of particles in light cone slice: 4023574'
+assert_file_contains $log 'Total number of particles in light cone slice: 709199'
+assert_file_contains $log 'Total number of particles in light cone slice: 1090764'
+assert_file_contains $log 'Total number of particles in light cone slice: 1342700'
+assert_file_contains $log 'Total number of particles in light cone slice: 1474660'
+assert_file_contains $log 'Total number of particles in light cone slice: 1557489'
+assert_file_contains $log 'Total number of particles in light cone slice: 1591160'
+assert_file_contains $log 'Total number of particles in light cone slice: 1603257'
+assert_file_contains $log 'Total number of particles in light cone slice: 1607204'
+
+assert_file_contains $log 'Writing 7666753 objects.'
+assert_file_contains $log 'Writing 4978336 objects.'
+assert_file_contains $log 'Writing 453 objects.'
+assert_file_contains $log 'Writing 2097152 objects.'
+assert_file_contains $log 'Writing 22062 objects.'
 assert_file_contains $log 'Writing 1607204 objects.'
 assert_file_contains $log 'Writing 4983 objects.'
 assert_file_contains $log 'sigma8.*0.815897'


### PR DESCRIPTION
Asserts on number of particles written and stored in the slices, asserts on the number of halos.

The purpose of the PR is to prepare for the relaxed-fof implementation, which changes the FOF api and may affect usmesh-fof.
