### PR TITLE
Use Consistent laplacian in 2lpt and PM.

### DIFF
--- a/api/fastpm/gravity.h
+++ b/api/fastpm/gravity.h
@@ -3,6 +3,12 @@ FASTPM_BEGIN_DECLS
 #define FASTPM_CRITICAL_DENSITY 27.7455 /* 1e10 Msun /h*/
 
 void
+fastpm_kernel_type_get_orders(FastPMKernelType type,
+    int *potorder,
+    int *gradorder,
+    int *deconvolveorder);
+
+void
 fastpm_solver_compute_force(FastPMSolver * fastpm,
     FastPMPainter * painter,
     FastPMSofteningType dealias,

--- a/api/fastpm/libfastpm.h
+++ b/api/fastpm/libfastpm.h
@@ -44,6 +44,7 @@ typedef enum { FASTPM_FORCE_FASTPM = 0,
 } FastPMForceType;
 
 typedef enum { FASTPM_KERNEL_3_4, FASTPM_KERNEL_3_2, FASTPM_KERNEL_5_4,
+               FASTPM_KERNEL_1_4,
                FASTPM_KERNEL_GADGET,
                FASTPM_KERNEL_EASTWOOD,
                FASTPM_KERNEL_NAIVE,

--- a/api/fastpm/transfer.h
+++ b/api/fastpm/transfer.h
@@ -16,7 +16,7 @@ void
 fastpm_apply_multiply_transfer(PM * pm, FastPMFloat * from, FastPMFloat * to, double value);
 
 void
-fastpm_apply_laplace_transfer(PM * pm, FastPMFloat * from, FastPMFloat * to);
+fastpm_apply_laplace_transfer(PM * pm, FastPMFloat * from, FastPMFloat * to, int order);
 
 void
 fastpm_apply_any_transfer(PM * pm, FastPMFloat * from, FastPMFloat * to, fastpm_fkfunc func, void * data);

--- a/libfastpm/gravity.c
+++ b/libfastpm/gravity.c
@@ -165,7 +165,6 @@ gravity_apply_kernel_transfer(FastPMKernelType type,
     fastpm_kernel_type_get_orders(type, &potorder, &gradorder, &deconvolveorder);
 
     while(deconvolveorder > 0) {
-        fastpm_info("Deconvolveing.... CIC.");
         fastpm_apply_decic_transfer(pm, canvas, canvas);
         deconvolveorder--;
     }

--- a/libfastpm/pm2lpt.c
+++ b/libfastpm/pm2lpt.c
@@ -10,8 +10,12 @@
 #include "pm2lpt.h"
 
 void 
-pm_2lpt_solve(PM * pm, FastPMFloat * delta_k, FastPMStore * p, double shift[3]) 
+pm_2lpt_solve(PM * pm, FastPMFloat * delta_k, FastPMStore * p, double shift[3], FastPMKernelType type)
 {
+    /* read out values at locations with an inverted shift */
+    int potorder, gradorder, deconvolveorder;
+    fastpm_kernel_type_get_orders(type, &potorder, &gradorder, &deconvolveorder);
+
     /* calculate dx1, dx2, for initial fluctuation delta_k.
      * shift: martin has shift = 0.5, 0.5, 0.5.
      * Use shift of 0, 0, 0 if in doublt. 
@@ -51,7 +55,7 @@ pm_2lpt_solve(PM * pm, FastPMFloat * delta_k, FastPMStore * p, double shift[3])
 
     for(d = 0; d < 3; d++) {
 
-        fastpm_apply_laplace_transfer(pm, delta_k, workspace);
+        fastpm_apply_laplace_transfer(pm, delta_k, workspace, potorder);
         fastpm_apply_diff_transfer(pm, workspace, workspace, d);
 
         pm_c2r(pm, workspace);
@@ -62,7 +66,7 @@ pm_2lpt_solve(PM * pm, FastPMFloat * delta_k, FastPMStore * p, double shift[3])
     } 
 
     for(d = 0; d< 3; d++) {
-        fastpm_apply_laplace_transfer(pm, delta_k, field[d]);
+        fastpm_apply_laplace_transfer(pm, delta_k, field[d], potorder);
         fastpm_apply_diff_transfer(pm, field[d], field[d], d);
         fastpm_apply_diff_transfer(pm, field[d], field[d], d);
 
@@ -82,7 +86,7 @@ pm_2lpt_solve(PM * pm, FastPMFloat * delta_k, FastPMStore * p, double shift[3])
         int d1 = D1[d];
         int d2 = D2[d];
 
-        fastpm_apply_laplace_transfer(pm, delta_k, workspace);
+        fastpm_apply_laplace_transfer(pm, delta_k, workspace, potorder);
         fastpm_apply_diff_transfer(pm, workspace, workspace, d1);
         fastpm_apply_diff_transfer(pm, workspace, workspace, d2);
 
@@ -100,7 +104,7 @@ pm_2lpt_solve(PM * pm, FastPMFloat * delta_k, FastPMStore * p, double shift[3])
          * We absorb some the negative factor in za transfer to below;
          *
          * */
-        fastpm_apply_laplace_transfer(pm, source, workspace);
+        fastpm_apply_laplace_transfer(pm, source, workspace, potorder);
         fastpm_apply_diff_transfer(pm, workspace, workspace, d);
 
         pm_c2r(pm, workspace);

--- a/libfastpm/pm2lpt.h
+++ b/libfastpm/pm2lpt.h
@@ -3,7 +3,7 @@ void
 pm_2lpt_init(PM * pm, FastPMStore * p, int Ngrid, double BoxSize, MPI_Comm comm);
 
 void 
-pm_2lpt_solve(PM * pm, FastPMFloat * delta_k, FastPMStore * p, double shift[3]);
+pm_2lpt_solve(PM * pm, FastPMFloat * delta_k, FastPMStore * p, double shift[3], FastPMKernelType type);
 
 void 
 pm_2lpt_evolve(double aout, FastPMStore * p, FastPMCosmology * c, int zaonly);

--- a/libfastpm/solver.c
+++ b/libfastpm/solver.c
@@ -149,8 +149,8 @@ fastpm_solver_setup_lpt(FastPMSolver * fastpm,
             shift0 = 0;
         }
         double shift[3] = {shift0, shift0, shift0};
-        /* read out values at locations with an inverted shift */
-        pm_2lpt_solve(basepm, delta_k_ic, p, shift);
+        /* ignore deconvolve order and grad order, since particles are likely on the grid.*/
+        pm_2lpt_solve(basepm, delta_k_ic, p, shift, fastpm->config->KERNEL_TYPE);
     }
 
     if(config->USE_DX1_ONLY == 1) {

--- a/src/lua-runtime-fastpm.lua
+++ b/src/lua-runtime-fastpm.lua
@@ -194,12 +194,13 @@ schema.declare{name='lc_glmatrix',     type='array:number',
 
 schema.declare{name='za',                      type='boolean', default=false, help='use ZA initial condition not 2LPT'}
 
-schema.declare{name='kernel_type',             type='enum', default="gadget", help='Force kernel; very little effect.'}
+schema.declare{name='kernel_type',             type='enum', default="1_4", help='Force kernel; affects low mass halos 3_4 gives more low mass halos; 1_4 is consistent with fastpm-python.'}
 schema.kernel_type.choices = {
-    ['3_4'] = 'FASTPM_KERNEL_3_4',
-    ['5_4'] = 'FASTPM_KERNEL_5_4',
+    ['1_4'] = 'FASTPM_KERNEL_1_4',  -- consistent with fastpm-python
+    ['3_4'] = 'FASTPM_KERNEL_3_4',  -- legacy fastpm
+    ['gadget'] = 'FASTPM_KERNEL_GADGET', -- GADGET long range without exp smoothing.
+    ['5_4'] = 'FASTPM_KERNEL_5_4',  -- very bad do not use
     ['eastwood'] = 'FASTPM_KERNEL_EASTWOOD',
-    ['gadget'] = 'FASTPM_KERNEL_GADGET',
     ['naive'] = 'FASTPM_KERNEL_NAIVE',
     ['3_2'] = 'FASTPM_KERNEL_3_2',
 }


### PR DESCRIPTION
This eases reverting to the legacy fastpm 3_4 used in hidden-valley.


The switch to 1_4 kernel (for consistency with fastpm-python) has killed
a lot of less massive halos (>>10% at 100 particles), such that the hidden-valley2
is drastically different form hidden-valley1 if we do not fully revert to
the legacy 3_4 where lpt and pm both uses the sinc based laplacian.