### PR TITLE
LPT linear density field respects pm_nc_factor.

### DIFF
--- a/libfastpm/solver.c
+++ b/libfastpm/solver.c
@@ -90,7 +90,7 @@ void fastpm_solver_init(FastPMSolver * fastpm,
 
     fastpm->basepm = malloc(sizeof(PM));
     pm_init(fastpm->basepm, &basepminit, fastpm->comm);
-    
+
     double shift0;
     if(config->USE_SHIFT) {
         shift0 = config->boxsize / config->nc * 0.5;
@@ -100,6 +100,8 @@ void fastpm_solver_init(FastPMSolver * fastpm,
     double shift[3] = {shift0, shift0, shift0};
 
     fastpm_store_fill(fastpm_solver_get_species(fastpm, FASTPM_SPECIES_CDM), fastpm->basepm, shift, NULL);
+
+    fastpm->pm = fastpm_find_pm(fastpm, 0.0);
 }
 
 void
@@ -112,7 +114,8 @@ fastpm_solver_setup_lpt(FastPMSolver * fastpm,
     FastPMStore * p = fastpm_solver_get_species(fastpm, species);
     if(!p) fastpm_raise(-1, "Species requested (%d) does not exist", species);
 
-    PM * basepm = fastpm->basepm;
+
+    PM * pm = fastpm->pm;
     FastPMConfig * config = fastpm->config;
 
     double BoxSize = fastpm->config->boxsize;
@@ -134,7 +137,7 @@ fastpm_solver_setup_lpt(FastPMSolver * fastpm,
     }
 
     FastPMLPTEvent event[1];
-    event->pm = basepm;
+    event->pm = pm;
     event->delta_k = delta_k_ic;
     event->p = p;
 
@@ -150,7 +153,7 @@ fastpm_solver_setup_lpt(FastPMSolver * fastpm,
         }
         double shift[3] = {shift0, shift0, shift0};
         /* ignore deconvolve order and grad order, since particles are likely on the grid.*/
-        pm_2lpt_solve(basepm, delta_k_ic, p, shift, fastpm->config->KERNEL_TYPE);
+        pm_2lpt_solve(pm, delta_k_ic, p, shift, fastpm->config->KERNEL_TYPE);
     }
 
     if(config->USE_DX1_ONLY == 1) {

--- a/libfastpm/vpm.c
+++ b/libfastpm/vpm.c
@@ -13,6 +13,8 @@ vpm_find(VPM * vpm, double a)
     for (i = 0; !vpm[i].end; i ++) {
         if(vpm[i].a_start > a) break;
     }
+    /* Start with the first pm. */
+    if (i == 0) i = 1;
     return &vpm[i-1];
 }
 

--- a/src/lua-runtime-fastpm.lua
+++ b/src/lua-runtime-fastpm.lua
@@ -35,7 +35,8 @@ end
 
 schema.declare{name='omega_m',           type='number', required=true, default=0.3, help="cdm + baryon density parameter at z=0"}
 schema.declare{name='h',                 type='number', required=true, default=0.7, help="Dimensionless Hubble parameter"}
-schema.declare{name='pm_nc_factor',      type='array:number',  required=true, help="A list of {a, PM resolution}, "}
+schema.declare{name='pm_nc_factor',      type='array:number',  required=true,
+    help="A list of {a, PM resolution}. Add an entry {0.0, 1} to set lpt linear field resolution to 1."}
 schema.declare{name='np_alloc_factor',   type='number', required=true, help="Over allocation factor for load imbalance" }
 schema.declare{name='compute_potential', type='boolean', required=false, default=false, help="Calculate the gravitional potential."}
 schema.declare{name='m_ncdm',            type='array:number', required=false, default={}, help="Mass of ncdm particles. Enter in descending order."}

--- a/tests/lightcone.lua
+++ b/tests/lightcone.lua
@@ -29,7 +29,7 @@ remove_cosmic_variance=true
 -------- Approximation Method ---------------
 force_mode = "fastpm"
 -- force_mode = "cola"
-pm_nc_factor = 2            -- Particle Mesh grid pm_nc_factor*nc per dimension in the beginning
+pm_nc_factor = {{0, 1}, {0.001, 2}}
 
 np_alloc_factor = 2.0      -- Amount of memory allocated for particle
 

--- a/tests/nbodykit.lua
+++ b/tests/nbodykit.lua
@@ -28,8 +28,9 @@ particle_fraction = 1.0
 --
 -------- Approximation Method ---------------
 force_mode = "fastpm"
+kernel_type = "1_4"
 
-pm_nc_factor = 2
+pm_nc_factor = {{0.0, 1}, {0.01, 2}}
 
 np_alloc_factor= 4.0      -- Amount of memory allocated for particle
 

--- a/tests/testconstrained.c
+++ b/tests/testconstrained.c
@@ -34,7 +34,7 @@ int main(int argc, char * argv[]) {
     FastPMSolver solver[1];
     fastpm_solver_init(solver, config, comm);
 
-    FastPMFloat * rho_init_ktruth = pm_alloc(solver->basepm);
+    FastPMFloat * rho_init_ktruth = pm_alloc(solver->pm);
 
     /* First establish the truth by 2lpt -- this will be replaced with PM. */
     struct fastpm_powerspec_eh_params eh = {
@@ -43,8 +43,8 @@ int main(int argc, char * argv[]) {
         .omegam = 0.260,
         .omegab = 0.044,
     };
-    fastpm_ic_fill_gaussiank(solver->basepm, rho_init_ktruth, 2004, FASTPM_DELTAK_GADGET);
-    fastpm_ic_induce_correlation(solver->basepm, rho_init_ktruth, (fastpm_fkfunc)fastpm_utils_powerspec_eh, &eh);
+    fastpm_ic_fill_gaussiank(solver->pm, rho_init_ktruth, 2004, FASTPM_DELTAK_GADGET);
+    fastpm_ic_induce_correlation(solver->pm, rho_init_ktruth, (fastpm_fkfunc)fastpm_utils_powerspec_eh, &eh);
 
     FastPM2PCF xi;
 
@@ -58,9 +58,9 @@ int main(int argc, char * argv[]) {
             },
     };
 
-    fastpm_cg_apply_constraints(&cg, solver->basepm, &xi, rho_init_ktruth);
+    fastpm_cg_apply_constraints(&cg, solver->pm, &xi, rho_init_ktruth);
 
-    pm_free(solver->basepm, rho_init_ktruth);
+    pm_free(solver->pm, rho_init_ktruth);
     fastpm_solver_destroy(solver);
     libfastpm_cleanup();
     MPI_Finalize();

--- a/tests/testlightcone.c
+++ b/tests/testlightcone.c
@@ -48,7 +48,7 @@ stage1(FastPMSolver * solver, FastPMLightCone * lc, FastPMFloat * rho_init_ktrut
 
     FastPMPainter painter[1];
 
-    fastpm_painter_init(painter, solver->basepm, solver->config->PAINTER_TYPE, solver->config->painter_support);
+    fastpm_painter_init(painter, solver->pm, solver->config->PAINTER_TYPE, solver->config->painter_support);
     fastpm_usmesh_destroy(usmesh);
 
 }
@@ -146,7 +146,7 @@ int main(int argc, char * argv[]) {
 
     fastpm_solver_init(solver, config, comm);
 
-    FastPMFloat * rho_init_ktruth = pm_alloc(solver->basepm);
+    FastPMFloat * rho_init_ktruth = pm_alloc(solver->pm);
 
     /* First establish the truth by 2lpt -- this will be replaced with PM. */
     struct fastpm_powerspec_eh_params eh = {
@@ -155,8 +155,8 @@ int main(int argc, char * argv[]) {
         .omegam = 0.260,
         .omegab = 0.044,
     };
-    fastpm_ic_fill_gaussiank(solver->basepm, rho_init_ktruth, 2004, FASTPM_DELTAK_GADGET);
-    fastpm_ic_induce_correlation(solver->basepm, rho_init_ktruth, (fastpm_fkfunc)fastpm_utils_powerspec_eh, &eh);
+    fastpm_ic_fill_gaussiank(solver->pm, rho_init_ktruth, 2004, FASTPM_DELTAK_GADGET);
+    fastpm_ic_induce_correlation(solver->pm, rho_init_ktruth, (fastpm_fkfunc)fastpm_utils_powerspec_eh, &eh);
 
     {
         int p = 0;
@@ -213,7 +213,7 @@ int main(int argc, char * argv[]) {
 
     fastpm_lc_destroy(lc);
 
-    pm_free(solver->basepm, rho_init_ktruth);
+    pm_free(solver->pm, rho_init_ktruth);
     fastpm_solver_destroy(solver);
 
     libfastpm_cleanup();

--- a/tests/testlightconeP.c
+++ b/tests/testlightconeP.c
@@ -39,7 +39,7 @@ int main(int argc, char * argv[]) {
     FastPMKickFactor kick;
     fastpm_solver_init(solver, config, comm);
 
-    FastPMFloat * rho_init_ktruth = pm_alloc(solver->basepm);
+    FastPMFloat * rho_init_ktruth = pm_alloc(solver->pm);
 
     /* First establish the truth by 2lpt -- this will be replaced with PM. */
     struct fastpm_powerspec_eh_params eh = {
@@ -48,8 +48,8 @@ int main(int argc, char * argv[]) {
         .omegam = 0.260,
         .omegab = 0.044,
     };
-    fastpm_ic_fill_gaussiank(solver->basepm, rho_init_ktruth, 2005, FASTPM_DELTAK_GADGET);
-    fastpm_ic_induce_correlation(solver->basepm, rho_init_ktruth, (fastpm_fkfunc)fastpm_utils_powerspec_eh, &eh);
+    fastpm_ic_fill_gaussiank(solver->pm, rho_init_ktruth, 2005, FASTPM_DELTAK_GADGET);
+    fastpm_ic_induce_correlation(solver->pm, rho_init_ktruth, (fastpm_fkfunc)fastpm_utils_powerspec_eh, &eh);
 
     FastPMLightConeP lcp[1] = {{
         .speedfactor = 1,//0.2,
@@ -137,7 +137,7 @@ int main(int argc, char * argv[]) {
 
     fastpm_lcp_destroy(lcp);
 
-    pm_free(solver->basepm, rho_init_ktruth);
+    pm_free(solver->pm, rho_init_ktruth);
     fastpm_solver_destroy(solver);
     libfastpm_cleanup();
     MPI_Finalize();

--- a/tests/testtimemachine.c
+++ b/tests/testtimemachine.c
@@ -38,7 +38,7 @@ int main(int argc, char * argv[]) {
 
     fastpm_init(solver, 0, 0, comm);
 
-    FastPMFloat * rho_init_ktruth = pm_alloc(solver->basepm);
+    FastPMFloat * rho_init_ktruth = pm_alloc(solver->pm);
 
     /* First establish the truth by 2lpt -- this will be replaced with PM. */
     struct fastpm_powerspec_eh_params eh = {
@@ -48,8 +48,8 @@ int main(int argc, char * argv[]) {
         .omegab = 0.044,
     };
     
-    fastpm_ic_fill_gaussiank(solver->basepm, rho_init_ktruth, 2004, FASTPM_DELTAK_GADGET);
-    fastpm_ic_induce_correlation(solver->basepm, rho_init_ktruth, (fastpm_fkfunc)fastpm_utils_powerspec_eh, &eh);
+    fastpm_ic_fill_gaussiank(solver->pm, rho_init_ktruth, 2004, FASTPM_DELTAK_GADGET);
+    fastpm_ic_induce_correlation(solver->pm, rho_init_ktruth, (fastpm_fkfunc)fastpm_utils_powerspec_eh, &eh);
 
     double time_step[] = {0.2, 0.4, 0.6, 0.8, 1.0};
     //double time_step[] = {0.1, 1.0};
@@ -58,9 +58,9 @@ int main(int argc, char * argv[]) {
     fastpm_tevo_evolve(solver, time_step, sizeof(time_step) / sizeof(time_step[0]));
 
     FastPMPainter painter[1];
-    fastpm_painter_init(painter, solver->basepm, solver->PAINTER_TYPE, solver->painter_support);
+    fastpm_painter_init(painter, solver->pm, solver->PAINTER_TYPE, solver->painter_support);
 
-    pm_free(solver->basepm, rho_init_ktruth);
+    pm_free(solver->pm, rho_init_ktruth);
 
 	fastpm_destroy(solver);
 


### PR DESCRIPTION
biwei has found using B=2 in LPT significantly improves quality
of halos at high redshift. This is consistent to other's observations.

Therefore we change LPT to use the pm_nc_factor value specified
in the parameter file.

To restore the old behavior of using B=1 for LPT,
 add a pm_nc_factor control point at a=0.0
for B=1, and a very small nonzero control point for B=2.

pm_nc_factor = {{0.0, 1}, {0.0001, 2}}

The tests are updated to use the old behavior.