### PR TITLE
Sort aout.

### DIFF
--- a/tests/nbodykit.lua
+++ b/tests/nbodykit.lua
@@ -12,7 +12,7 @@ boxsize = 384.0
 -- time_step = linspace(0.01, 1.0, 10)
 time_step = linspace(0.1, 1, 3)
 
-output_redshifts= {0.5, 0.0}  -- redshifts of output
+output_redshifts= {0.0, 0.5}  -- redshifts of output
 
 -- Cosmology --
 omega_m = 0.307494


### PR DESCRIPTION
The new snapshot search algorithm requires aout to be sorted.
If output redshift is not sorted, we end up not taking snapshots!