### PR TITLE
Add lpt_nc_factor.

### DIFF
--- a/api/fastpm/solver.h
+++ b/api/fastpm/solver.h
@@ -50,6 +50,7 @@ typedef struct {
     size_t nc;
     double boxsize;
     double alloc_factor;
+    int lpt_nc_factor;
 
     FastPMCosmology * cosmology;
 
@@ -105,6 +106,7 @@ typedef struct {
     VPM * vpm_list;
 
     PM * basepm;
+    PM * lptpm;
 } FastPMSolver;
 
 enum FastPMAction {

--- a/src/fastpm.c
+++ b/src/fastpm.c
@@ -180,6 +180,7 @@ int main(int argc, char ** argv) {
     FastPMConfig * config = & (FastPMConfig) {
         .nc = CONF(prr->lua, nc),
         .alloc_factor = CONF(prr->lua, np_alloc_factor),
+        .lpt_nc_factor = CONF(prr->lua, lpt_nc_factor),
         .vpminit = vpminit,
         .boxsize = CONF(prr->lua, boxsize),
         .cosmology = cosmology,

--- a/src/lua-runtime-fastpm.lua
+++ b/src/lua-runtime-fastpm.lua
@@ -42,6 +42,7 @@ schema.declare{name='N_eff',             type='number', required=false, default=
 schema.declare{name='N_nu',              type='number', required=false, default=0, help="Total number of neutrinos, massive and massless."}
 schema.declare{name='m_ncdm',            type='array:number', required=false, default={}, help="Mass of ncdm particles in eV. Enter in descending order."}
 schema.declare{name='pm_nc_factor',      type='array:number',  required=true, help="A list of {a, PM resolution}, "}
+schema.declare{name='lpt_nc_factor',     type='number', required=false, default=1, help="PM resolution use in lpt and linear density field."}
 schema.declare{name='np_alloc_factor',   type='number', required=true, help="Over allocation factor for load imbalance" }
 schema.declare{name='compute_potential', type='boolean', required=false, default=false, help="Calculate the gravitional potential."}
 schema.declare{name='n_shell',           type='number', required=false, default=10, help="Number of shells of FD distribution for ncdm splitting."}

--- a/tests/lightcone.lua
+++ b/tests/lightcone.lua
@@ -30,8 +30,8 @@ remove_cosmic_variance=true
 force_mode = "fastpm"
 -- force_mode = "cola"
 growth_mode = "LCDM"
-pm_nc_factor = {{0, 1}, {0.001, 2}}
-
+pm_nc_factor = 2
+lpt_nc_factor = 1
 np_alloc_factor = 2.0      -- Amount of memory allocated for particle
 
 -------- Output ---------------

--- a/tests/nbodykit.lua
+++ b/tests/nbodykit.lua
@@ -32,7 +32,8 @@ kernel_type = "1_4"
 
 growth_mode = "LCDM"
 
-pm_nc_factor = {{0.0, 1}, {0.01, 2}}
+pm_nc_factor = 2
+lpt_nc_factor = 1
 
 np_alloc_factor= 4.0      -- Amount of memory allocated for particle
 

--- a/tests/standard.lua
+++ b/tests/standard.lua
@@ -151,7 +151,8 @@ else
 end
 -------- Approximation Method ---------------
 
-pm_nc_factor = {{0, 2}, {0.5, 3}}            -- Particle Mesh grid pm_nc_factor*nc per dimension in the beginning
+pm_nc_factor = 3            -- Particle Mesh grid pm_nc_factor*nc per dimension in the beginning
+lpt_nc_factor = 1
 
 np_alloc_factor= 4.0      -- Amount of memory allocated for particle
 


### PR DESCRIPTION
This deprecates the pm_nc_factor= {{0, 1}, ....} workaround.
Also fixes the transpose of the gaussian field, speeding up
the ic generation.